### PR TITLE
fix: use chart appVersion for recipe-rip image tag

### DIFF
--- a/charts/recipe-rip/Chart.yaml
+++ b/charts/recipe-rip/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: recipe-rip
 description: Recipe management app (wrapper chart)
 type: application
-version: 0.2.1
+version: 0.2.2
 appVersion: "0.1.0"
 maintainers:
   - name: homelab

--- a/charts/recipe-rip/values.yaml
+++ b/charts/recipe-rip/values.yaml
@@ -4,7 +4,6 @@ namespace: default
 recipe-rip:
   image:
     repository: ghcr.io/jcserv/recipe.rip
-    tag: sha-cb7bcef
     pullPolicy: IfNotPresent
 
   replicaCount: 1


### PR DESCRIPTION
## Summary
- Remove hardcoded `tag: sha-cb7bcef` from recipe-rip values
- The upstream chart now defaults to `.Chart.AppVersion` when no tag override is set (jcserv/recipe.rip#10)
- Each Renovate chart version bump will automatically pull the matching Docker image

## Context
Renovate was bumping the Helm chart dependency but not the Docker image tag, causing pods to run stale code after chart upgrades.

## Test plan
- [ ] After merging, verify the recipe-rip pod restarts with the correct image (matching the chart's appVersion)