### PR TITLE
feat(librechat): add LibreChat + extract shared Meilisearch chart

### DIFF
--- a/charts/librechat/Chart.lock
+++ b/charts/librechat/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: librechat
+  repository: oci://ghcr.io/danny-avila/librechat-chart
+  version: 2.0.6
+digest: sha256:b338f982642585009be4aff1d8cff313b38c4ebc663292722372799579f0c84a
+generated: "2026-06-22T15:19:29.117812-04:00"

--- a/charts/librechat/Chart.yaml
+++ b/charts/librechat/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: librechat
+description: LibreChat - self-hosted multi-model AI chat UI
+type: application
+version: 1.0.0
+appVersion: "v0.8.7-rc1"
+maintainers:
+  - name: homelab
+
+dependencies:
+  - name: librechat
+    version: "2.0.6"
+    repository: oci://ghcr.io/danny-avila/librechat-chart

--- a/charts/librechat/templates/infisical-secret.yaml
+++ b/charts/librechat/templates/infisical-secret.yaml
@@ -1,0 +1,43 @@
+{{- /*
+InfisicalSecret CR — sole secret source for LibreChat (no sealed-secrets).
+The operator pulls from Infisical (folder /librechat) and materializes the
+`librechat-credentials-env` Secret, which the upstream chart loads via envFrom
+(overriding the configEnv ConfigMap defaults). meili-master-key must match the
+value in the shared /meilisearch folder. See docs/runbooks/INFISICAL_MIGRATION.md.
+*/ -}}
+{{- if .Values.infisical.enabled }}
+apiVersion: secrets.infisical.com/v1alpha1
+kind: InfisicalSecret
+metadata:
+  name: librechat-infisical
+  labels:
+    app: librechat
+spec:
+  hostAPI: {{ .Values.infisical.hostAPI | quote }}
+  syncConfig:
+    resyncInterval: {{ .Values.infisical.resyncInterval | quote }}
+    instantUpdates: {{ .Values.infisical.instantUpdates }}
+  authentication:
+    universalAuth:
+      secretsScope:
+        projectSlug: {{ .Values.infisical.projectSlug | quote }}
+        envSlug: {{ .Values.infisical.envSlug | quote }}
+        secretsPath: {{ .Values.infisical.secretsPath | quote }}
+      credentialsRef:
+        secretName: {{ .Values.infisical.credentialsRef.secretName | quote }}
+        secretNamespace: {{ .Values.infisical.credentialsRef.secretNamespace | quote }}
+  managedKubeSecretReferences:
+    - secretName: librechat-credentials-env
+      secretNamespace: {{ .Release.Namespace }}
+      creationPolicy: "Owner"
+      secretType: Opaque
+      template:
+        includeAllSecrets: false
+        data:
+          CREDS_KEY: '{{ `{{ (index . "creds-key").Value }}` }}'
+          CREDS_IV: '{{ `{{ (index . "creds-iv").Value }}` }}'
+          JWT_SECRET: '{{ `{{ (index . "jwt-secret").Value }}` }}'
+          JWT_REFRESH_SECRET: '{{ `{{ (index . "jwt-refresh-secret").Value }}` }}'
+          MEILI_MASTER_KEY: '{{ `{{ (index . "meili-master-key").Value }}` }}'
+          OPENROUTER_KEY: '{{ `{{ (index . "openrouter-key").Value }}` }}'
+{{- end }}

--- a/charts/librechat/templates/mongodb.yaml
+++ b/charts/librechat/templates/mongodb.yaml
@@ -1,0 +1,98 @@
+{{- /*
+Bundled MongoDB for LibreChat — plain Deployment using the official (arm64)
+mongo image instead of the upstream chart's Bitnami subchart. Static resource
+names to avoid helper collisions with the librechat subchart.
+*/ -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: librechat-mongodb
+  namespace: {{ .Values.namespace }}
+  labels:
+    app.kubernetes.io/name: librechat-mongodb
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    helm.sh/resource-policy: keep
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: {{ .Values.mongo.persistence.storageClass }}
+  resources:
+    requests:
+      storage: {{ .Values.mongo.persistence.size }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: librechat-mongodb
+  namespace: {{ .Values.namespace }}
+  labels:
+    app.kubernetes.io/name: librechat-mongodb
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: librechat-mongodb
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: librechat-mongodb
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      {{- with .Values.mongo.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: mongodb
+          image: "{{ .Values.mongo.image.repository }}:{{ .Values.mongo.image.tag }}"
+          imagePullPolicy: {{ .Values.mongo.image.pullPolicy }}
+          ports:
+            - name: mongodb
+              containerPort: 27017
+              protocol: TCP
+          volumeMounts:
+            - name: data
+              mountPath: /data/db
+          resources:
+            {{- toYaml .Values.mongo.resources | nindent 12 }}
+          livenessProbe:
+            tcpSocket:
+              port: mongodb
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            tcpSocket:
+              port: mongodb
+            initialDelaySeconds: 5
+            periodSeconds: 5
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: librechat-mongodb
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: librechat-mongodb
+  namespace: {{ .Values.namespace }}
+  labels:
+    app.kubernetes.io/name: librechat-mongodb
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 27017
+      targetPort: mongodb
+      protocol: TCP
+      name: mongodb
+  selector:
+    app.kubernetes.io/name: librechat-mongodb
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/librechat/values.yaml
+++ b/charts/librechat/values.yaml
@@ -1,0 +1,136 @@
+namespace: default
+
+# --- Bundled MongoDB (official image, arm64-native) ---------------------------
+# LibreChat's upstream chart bundles a Bitnami MongoDB subchart, which is risky
+# on the arm64 Pi cluster. Mirror the repo convention (open-archiver bundles its
+# own Postgres) and run a plain Deployment with the official mongo image. Only
+# LibreChat uses it. In-cluster only, no auth (consistent with shared valkey).
+mongo:
+  image:
+    repository: mongo
+    tag: "8.0"
+    pullPolicy: IfNotPresent
+  persistence:
+    storageClass: local-path
+    size: 8Gi
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 1000m
+      memory: 1Gi
+  # Prefer Pi5 (8GB) — RAM headroom.
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          preference:
+            matchExpressions:
+              - key: kubernetes.io/hostname
+                operator: In
+                values:
+                  - pi5-01
+
+# Infisical Secrets Operator — sole secret source. Folder /librechat in project
+# homelab-nkcl, env prod. Materializes the `librechat-credentials-env` Secret
+# the upstream chart loads via envFrom (it overrides configEnv defaults).
+infisical:
+  enabled: true
+  hostAPI: http://infisical-infisical-standalone-infisical.default.svc.cluster.local:8080/api
+  resyncInterval: 60s
+  instantUpdates: false
+  projectSlug: homelab-nkcl
+  envSlug: prod
+  secretsPath: /librechat
+  credentialsRef:
+    secretName: infisical-machine-identity
+    secretNamespace: infisical-secrets-operator
+
+# --- Upstream LibreChat chart (subchart name = librechat) ---------------------
+librechat:
+  global:
+    librechat:
+      existingSecretName: librechat-credentials-env
+
+  librechat:
+    existingSecretName: librechat-credentials-env
+    # Non-secret env. Secret keys (CREDS_KEY/CREDS_IV/JWT_SECRET/
+    # JWT_REFRESH_SECRET/MEILI_MASTER_KEY/OPENROUTER_KEY) come from the Secret,
+    # which overrides this configMap at runtime (envFrom order).
+    configEnv:
+      ALLOW_REGISTRATION: "true"
+      ALLOW_EMAIL_LOGIN: "true"
+      # Reuse bundled-but-disabled services with shared cluster datastores.
+      MONGO_URI: mongodb://librechat-mongodb.default.svc.cluster.local:27017/LibreChat
+      MEILI_HOST: http://meilisearch.default.svc.cluster.local:7700
+      SEARCH: "true"
+      USE_REDIS: "true"
+      REDIS_URI: redis://valkey.default.svc.cluster.local:6379/2
+    # librechat.yaml — defines the OpenRouter custom endpoint. Phase 2 (MCP
+    # server) adds an `mcpServers:` block here.
+    configYamlContent: |
+      version: 1.2.1
+      cache: true
+      endpoints:
+        custom:
+          - name: "OpenRouter"
+            apiKey: "${OPENROUTER_KEY}"
+            baseURL: "https://openrouter.ai/api/v1"
+            models:
+              default: ["anthropic/claude-sonnet-4", "openai/gpt-4o-mini"]
+              fetch: true
+            titleConvo: true
+            titleModel: "openai/gpt-4o-mini"
+            modelDisplayLabel: "OpenRouter"
+    imageVolume:
+      enabled: true
+      size: 10G
+      accessModes: ReadWriteOnce
+      storageClassName: local-path
+
+  # Disable bundled datastores — we use the bundled mongo Deployment above and
+  # the shared charts/meilisearch + charts/valkey services.
+  mongodb:
+    enabled: false
+  meilisearch:
+    enabled: false
+  redis:
+    enabled: false
+  librechat-rag-api:
+    enabled: false
+
+  ingress:
+    enabled: true
+    className: nginx
+    annotations:
+      nginx.ingress.kubernetes.io/ssl-redirect: "true"
+      nginx.ingress.kubernetes.io/proxy-body-size: "25m"
+    hosts:
+      - host: chat.jarrodservilla.com
+        paths:
+          - path: /
+            pathType: Prefix
+    tls:
+      - secretName: wildcard-jarrodservilla-tls
+        hosts:
+          - chat.jarrodservilla.com
+
+  resources:
+    requests:
+      cpu: 200m
+      memory: 512Mi
+    limits:
+      memory: 2Gi
+
+  # Prefer Pi5 (8GB).
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          preference:
+            matchExpressions:
+              - key: kubernetes.io/hostname
+                operator: In
+                values:
+                  - pi5-01

--- a/charts/meilisearch/Chart.yaml
+++ b/charts/meilisearch/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v2
+name: meilisearch
+description: Shared Meilisearch instance for cluster services (open-archiver, librechat)
+type: application
+version: 1.0.0
+appVersion: "1.38.2"
+keywords:
+  - meilisearch
+  - search
+home: https://www.meilisearch.com
+sources:
+  - https://github.com/meilisearch/meilisearch
+maintainers:
+  - name: homelab

--- a/charts/meilisearch/templates/_helpers.tpl
+++ b/charts/meilisearch/templates/_helpers.tpl
@@ -1,0 +1,49 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "meilisearch.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "meilisearch.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "meilisearch.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "meilisearch.labels" -}}
+helm.sh/chart: {{ include "meilisearch.chart" . }}
+{{ include "meilisearch.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "meilisearch.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "meilisearch.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/meilisearch/templates/deployment.yaml
+++ b/charts/meilisearch/templates/deployment.yaml
@@ -1,24 +1,21 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "open-archiver.fullname" . }}-meilisearch
+  name: {{ include "meilisearch.fullname" . }}
   namespace: {{ .Values.namespace }}
   labels:
-    {{- include "open-archiver.labels" . | nindent 4 }}
-    component: meilisearch
+    {{- include "meilisearch.labels" . | nindent 4 }}
 spec:
   replicas: 1
   strategy:
     type: Recreate
   selector:
     matchLabels:
-      {{- include "open-archiver.selectorLabels" . | nindent 6 }}
-      component: meilisearch
+      {{- include "meilisearch.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        {{- include "open-archiver.selectorLabels" . | nindent 8 }}
-        component: meilisearch
+        {{- include "meilisearch.selectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.affinity }}
       affinity:
@@ -26,8 +23,8 @@ spec:
       {{- end }}
       containers:
         - name: meilisearch
-          image: "{{ .Values.meilisearch.image.repository }}:{{ .Values.meilisearch.image.tag }}"
-          imagePullPolicy: {{ .Values.meilisearch.image.pullPolicy }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
               containerPort: 7700
@@ -41,12 +38,12 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.existingSecret.name }}
-                  key: meili-master-key
+                  key: {{ .Values.existingSecret.key }}
           volumeMounts:
             - name: meilidata
               mountPath: /meili_data
           resources:
-            {{- toYaml .Values.meilisearch.resources | nindent 12 }}
+            {{- toYaml .Values.resources | nindent 12 }}
           livenessProbe:
             httpGet:
               path: /health
@@ -61,24 +58,9 @@ spec:
             periodSeconds: 5
       volumes:
         - name: meilidata
+          {{- if .Values.persistence.enabled }}
           persistentVolumeClaim:
-            claimName: {{ include "open-archiver.fullname" . }}-meilidata
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: {{ include "open-archiver.fullname" . }}-meilisearch
-  namespace: {{ .Values.namespace }}
-  labels:
-    {{- include "open-archiver.labels" . | nindent 4 }}
-    component: meilisearch
-spec:
-  type: ClusterIP
-  ports:
-    - name: http
-      port: 7700
-      targetPort: http
-      protocol: TCP
-  selector:
-    {{- include "open-archiver.selectorLabels" . | nindent 4 }}
-    component: meilisearch
+            claimName: {{ include "meilisearch.fullname" . }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}

--- a/charts/meilisearch/templates/infisical-secret.yaml
+++ b/charts/meilisearch/templates/infisical-secret.yaml
@@ -1,0 +1,38 @@
+{{- /*
+InfisicalSecret CR — sole secret source for this chart (no sealed-secrets).
+The operator pulls from Infisical (folder /meilisearch) and materializes the
+`meilisearch-secrets` Secret holding the master key. The master key is only an
+API gate, not tied to stored data; consumer charts keep their own copy set to
+the same value. See docs/runbooks/INFISICAL_MIGRATION.md.
+*/ -}}
+{{- if .Values.infisical.enabled }}
+apiVersion: secrets.infisical.com/v1alpha1
+kind: InfisicalSecret
+metadata:
+  name: meilisearch-infisical
+  labels:
+    app: meilisearch
+spec:
+  hostAPI: {{ .Values.infisical.hostAPI | quote }}
+  syncConfig:
+    resyncInterval: {{ .Values.infisical.resyncInterval | quote }}
+    instantUpdates: {{ .Values.infisical.instantUpdates }}
+  authentication:
+    universalAuth:
+      secretsScope:
+        projectSlug: {{ .Values.infisical.projectSlug | quote }}
+        envSlug: {{ .Values.infisical.envSlug | quote }}
+        secretsPath: {{ .Values.infisical.secretsPath | quote }}
+      credentialsRef:
+        secretName: {{ .Values.infisical.credentialsRef.secretName | quote }}
+        secretNamespace: {{ .Values.infisical.credentialsRef.secretNamespace | quote }}
+  managedKubeSecretReferences:
+    - secretName: {{ .Values.existingSecret.name }}
+      secretNamespace: {{ .Release.Namespace }}
+      creationPolicy: "Owner"
+      secretType: Opaque
+      template:
+        includeAllSecrets: false
+        data:
+          meili-master-key: '{{ `{{ (index . "meili-master-key").Value }}` }}'
+{{- end }}

--- a/charts/meilisearch/templates/pvc.yaml
+++ b/charts/meilisearch/templates/pvc.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "meilisearch.fullname" . }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "meilisearch.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/resource-policy: keep
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: {{ .Values.persistence.storageClass }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+{{- end }}

--- a/charts/meilisearch/templates/service.yaml
+++ b/charts/meilisearch/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "meilisearch.fullname" . }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "meilisearch.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "meilisearch.selectorLabels" . | nindent 4 }}

--- a/charts/meilisearch/values.yaml
+++ b/charts/meilisearch/values.yaml
@@ -1,0 +1,57 @@
+namespace: default
+
+# Pin exact tag — a rolling minor bump can push the engine past the on-disk DB
+# version and CrashLoop. See docs + meilisearch-version-pinning memory.
+image:
+  repository: getmeili/meilisearch
+  tag: "v1.38.2"
+  pullPolicy: IfNotPresent
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: 1000m
+    memory: 1Gi
+
+persistence:
+  enabled: true
+  storageClass: local-path
+  size: 8Gi
+
+# Prefer Pi5 (8GB) — indexing is memory-heavy.
+affinity:
+  nodeAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        preference:
+          matchExpressions:
+            - key: kubernetes.io/hostname
+              operator: In
+              values:
+                - pi5-01
+
+service:
+  type: ClusterIP
+  port: 7700
+
+# Master key sourced from the Infisical-managed Secret.
+existingSecret:
+  name: meilisearch-secrets
+  key: meili-master-key
+
+# Infisical Secrets Operator — sole secret source. Folder /meilisearch in
+# project homelab-nkcl, env prod. The master key is only an API gate (not tied
+# to stored data); every consumer keeps its own copy set to this same value.
+infisical:
+  enabled: true
+  hostAPI: http://infisical-infisical-standalone-infisical.default.svc.cluster.local:8080/api
+  resyncInterval: 60s
+  instantUpdates: false
+  projectSlug: homelab-nkcl
+  envSlug: prod
+  secretsPath: /meilisearch
+  credentialsRef:
+    secretName: infisical-machine-identity
+    secretNamespace: infisical-secrets-operator

--- a/charts/open-archiver/Chart.yaml
+++ b/charts/open-archiver/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: open-archiver
 description: OpenArchiver email archiving (Gmail/M365/IMAP/PST ingestion, full-text search)
 type: application
-version: 0.1.3
+version: 0.1.4
 appVersion: "v0.5.0"
 maintainers:
   - name: homelab

--- a/charts/open-archiver/templates/pvc.yaml
+++ b/charts/open-archiver/templates/pvc.yaml
@@ -13,19 +13,3 @@ spec:
   resources:
     requests:
       storage: {{ .Values.postgres.persistence.size }}
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: {{ include "open-archiver.fullname" . }}-meilidata
-  namespace: {{ .Values.namespace }}
-  labels:
-    {{- include "open-archiver.labels" . | nindent 4 }}
-    component: meilisearch
-spec:
-  accessModes:
-    - ReadWriteOnce
-  storageClassName: {{ .Values.meilisearch.persistence.storageClass }}
-  resources:
-    requests:
-      storage: {{ .Values.meilisearch.persistence.size }}

--- a/charts/open-archiver/values.yaml
+++ b/charts/open-archiver/values.yaml
@@ -39,7 +39,8 @@ env:
   # Allow deleting archived emails + ingestion sources (instance-wide).
   # Off by default upstream for compliance/immutability.
   ENABLE_DELETION: "true"
-  MEILI_HOST: http://open-archiver-meilisearch:7700
+  # Shared cluster Meilisearch (charts/meilisearch).
+  MEILI_HOST: http://meilisearch.default.svc.cluster.local:7700
   # Shared cluster Valkey (charts/valkey) — unauthenticated, in-cluster only.
   REDIS_HOST: valkey.default.svc.cluster.local
   REDIS_PORT: "6379"
@@ -107,22 +108,6 @@ postgres:
     limits:
       cpu: 500m
       memory: 512Mi
-
-meilisearch:
-  image:
-    repository: getmeili/meilisearch
-    tag: "v1.48.0"
-    pullPolicy: IfNotPresent
-  persistence:
-    storageClass: local-path
-    size: 5Gi
-  resources:
-    requests:
-      cpu: 100m
-      memory: 256Mi
-    limits:
-      cpu: 1000m
-      memory: 1Gi
 
 # Infisical Secrets Operator — sole secret source for this chart (no
 # sealed-secrets). Folder /open-archiver in project homelab-nkcl, env prod.

--- a/values/network.yaml
+++ b/values/network.yaml
@@ -55,6 +55,7 @@ customDnsEntries:
   - "10.2.1.200 ai.jarrodservilla.com"
   - "10.2.1.200 infisical.jarrodservilla.com"
   - "10.2.1.200 archive.jarrodservilla.com"
+  - "10.2.1.200 chat.jarrodservilla.com"
   # NAS services
   - "10.2.1.200 qbittorrent.jarrodservilla.com"
   - "10.2.1.200 radarr.jarrodservilla.com"


### PR DESCRIPTION
Deploy self-hosted LibreChat (chat.jarrodservilla.com) and extract Meilisearch out of open-archiver into a shared cluster chart so both services share one search instance instead of running duplicate pods on the RAM-constrained Pi cluster.

Key changes:
- Add charts/meilisearch: standalone shared Meili (mirrors charts/valkey), Infisical-sourced master key, local-path PVC, pinned to v1.38.2 to match the existing on-disk DB version (a rolling bump past it CrashLoops)
- Add charts/librechat: wraps the official OCI chart, bundled MongoDB as a plain Deployment on the official arm64 image (Bitnami subchart disabled), reuses shared valkey (db2) and shared Meili via configEnv, OpenRouter endpoint via configYamlContent, nginx ingress + wildcard TLS
- open-archiver: remove embedded Meilisearch (Deployment/Service/PVC) and repoint MEILI_HOST at the shared service
- network: add chat.jarrodservilla.com DNS entry

Claude-Session: https://claude.ai/code/session_014Rfuk26tUrSe5g1reBtXWH