### PR TITLE
feat(terraform): bootstrap OpenTofu skeleton + Phase 1 B2 import (plan-only)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,11 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - 'terraform/**'
   pull_request:
+    paths-ignore:
+      - 'terraform/**'
 
 permissions:
   contents: read

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -18,9 +18,13 @@ permissions:
 
 env:
   TF_VAR_state_passphrase: ${{ secrets.TF_STATE_PASSPHRASE }}
-  # Used by both the s3 state backend and the b2 provider (reuse the Tier-0 mgmt key).
+  # b2 provider creds (Tier-0 mgmt key).
   B2_APPLICATION_KEY_ID: ${{ secrets.B2_APPLICATION_KEY_ID }}
   B2_APPLICATION_KEY: ${{ secrets.B2_APPLICATION_KEY }}
+  # s3 state backend creds: B2's S3 endpoint uses the AWS SDK, which reads the
+  # standard AWS env vars (NOT the B2_ ones). Same Tier-0 B2 mgmt key, AWS-named.
+  AWS_ACCESS_KEY_ID: ${{ secrets.B2_APPLICATION_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.B2_APPLICATION_KEY }}
 
 jobs:
   plan:

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,0 +1,124 @@
+name: terraform
+
+# OpenTofu for the external/cloud gap (B2/DNS/Tailscale/Authentik/Infisical structure).
+# Fully separate from ci.yml (Helm). Only runs on terraform/** changes.
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'terraform/**'
+  pull_request:
+    paths:
+      - 'terraform/**'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+env:
+  TF_VAR_state_passphrase: ${{ secrets.TF_STATE_PASSPHRASE }}
+  # Used by both the s3 state backend and the b2 provider (reuse the Tier-0 mgmt key).
+  B2_APPLICATION_KEY_ID: ${{ secrets.B2_APPLICATION_KEY_ID }}
+  B2_APPLICATION_KEY: ${{ secrets.B2_APPLICATION_KEY }}
+
+jobs:
+  plan:
+    name: tofu plan (PR)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    defaults:
+      run:
+        working-directory: terraform
+    steps:
+      - uses: actions/checkout@v7.0.0
+
+      - name: Install Infisical CLI
+        run: |
+          curl -1sLf 'https://artifacts-cli.infisical.com/setup.deb.sh' | sudo -E bash
+          sudo apt-get update && sudo apt-get install -y infisical
+
+      - name: Set up OpenTofu
+        uses: opentofu/setup-opentofu@v1
+        with:
+          tofu_version: 1.8.0
+
+      # Tailscale not needed for the B2-only phase (B2 is reached over the public S3
+      # endpoint). Re-enable once cluster-touching modules (Infisical/node labels) land:
+      # - name: Connect to Tailscale
+      #   uses: tailscale/github-action@v4
+      #   with:
+      #     oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+      #     oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+      #     tags: tag:github-actions
+
+      - name: tofu init
+        run: tofu init -input=false
+
+      - name: tofu plan
+        id: plan
+        run: tofu plan -input=false -no-color -out=tfplan 2>&1 | tee plan.txt
+
+      - name: Post plan to PR
+        uses: actions/github-script@v7
+        if: always()
+        with:
+          script: |
+            const fs = require('fs');
+            let plan = '';
+            try { plan = fs.readFileSync('terraform/plan.txt', 'utf8'); }
+            catch (e) { plan = 'No plan output.'; }
+            const max = 60000;
+            if (plan.length > max) plan = plan.slice(0, max) + '\n...(truncated)...';
+            const body = [
+              '### `tofu plan`',
+              '',
+              '```',
+              plan,
+              '```',
+            ].join('\n');
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body,
+            });
+
+  apply:
+    name: tofu apply (merge)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    # Required-reviewer gate (operator) lives on this GitHub Environment.
+    environment: terraform-prod
+    # Locking substitute (B2 has no DynamoDB-style lock) — serialize applies.
+    concurrency:
+      group: terraform
+      cancel-in-progress: false
+    defaults:
+      run:
+        working-directory: terraform
+    steps:
+      - uses: actions/checkout@v7.0.0
+
+      - name: Install Infisical CLI
+        run: |
+          curl -1sLf 'https://artifacts-cli.infisical.com/setup.deb.sh' | sudo -E bash
+          sudo apt-get update && sudo apt-get install -y infisical
+
+      - name: Set up OpenTofu
+        uses: opentofu/setup-opentofu@v1
+        with:
+          tofu_version: 1.8.0
+
+      # - name: Connect to Tailscale
+      #   uses: tailscale/github-action@v4
+      #   with:
+      #     oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+      #     oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+      #     tags: tag:github-actions
+
+      - name: tofu init
+        run: tofu init -input=false
+
+      - name: tofu apply
+        run: tofu apply -input=false -auto-approve

--- a/.gitignore
+++ b/.gitignore
@@ -37,11 +37,14 @@ kubeconfig
 
 scripts/.venv
 
-# Terraform (if used later)
+# Terraform / OpenTofu (terraform/)
 .terraform/
 *.tfstate
 *.tfstate.backup
 .terraform.lock.hcl
+*.tfplan
+*.tfvars
+!*.tfvars.example
 
 # IDE
 .vscode/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,21 @@ The `.env` file (not committed) holds raw credentials. Never commit unsealed sec
 
 Renovate auto-creates PRs for Helm chart and Docker image updates (config in `renovate.json`). PostgreSQL updates in `charts/authentik/values.yaml` are disabled (requires manual migration). Renovate auto-bumps chart versions in `Chart.yaml` on dependency changes.
 
+### OpenTofu (`terraform/`)
+
+`terraform/` uses **OpenTofu** (`tofu`, not Terraform) to manage only the external/cloud
+"gap": **B2 buckets/keys, DNS, Tailscale, Authentik, and Infisical structure**. The boundary
+is hard: **TF = external gap; Helm = all in-cluster workloads.** Never put `helm_release` or
+workload `kubernetes` resources under TF, and never touch `charts/**` from TF.
+
+State lives in the hand-made B2 bucket `homelab-tofu-state-dd43bf5b` (`ca-east-006`) with
+native state encryption. A separate workflow `.github/workflows/terraform.yml` (triggered only
+on `terraform/**`) runs plan-on-PR / apply-on-merge; `ci.yml` ignores `terraform/**`. Applies
+are serialized via a `terraform` concurrency group (B2 has no S3 locking) — never `tofu apply`
+locally. The 4 Tier-0 seeded roots (B2 mgmt key, state bucket, `TF_STATE_PASSPHRASE`, Infisical
+bootstrap identity) live in the password manager + GH secrets, never in Infisical or state.
+See `terraform/README.md`.
+
 ### Non-Kubernetes Components
 
 `docker/` contains Docker Compose configs running on the NAS (not part of the K8s cluster):

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -24,7 +24,9 @@ Because Infisical runs *in the cluster*, full DR cannot bootstrap from Infisical
 password manager is the true recovery root.**
 
 1. **B2 management app key** — account-wide create/list buckets+keys. GH secrets
-   `B2_APPLICATION_KEY_ID` / `B2_APPLICATION_KEY` (reused for both the s3 backend and the b2 provider).
+   `B2_APPLICATION_KEY_ID` / `B2_APPLICATION_KEY`. The **b2 provider** reads these directly.
+   The **s3 state backend** uses the AWS SDK and reads the standard `AWS_ACCESS_KEY_ID` /
+   `AWS_SECRET_ACCESS_KEY` env vars — set those to the *same* B2 keyID/appKey (AWS-named).
 2. **State bucket `homelab-tofu-state-dd43bf5b`** — made by hand (private, `ca-east-006`).
    Can't be TF-managed: it stores the state that would manage it.
 3. **`TF_STATE_PASSPHRASE`** — PBKDF2 passphrase for native state encryption. GH secret +
@@ -50,11 +52,14 @@ Already-existing GH secrets reused later: `KUBE_CONFIG`, `TS_OAUTH_CLIENT_ID`, `
 
 ```bash
 cd terraform
-export TF_VAR_state_passphrase=...     # = TF_STATE_PASSPHRASE
-export B2_APPLICATION_KEY_ID=...       # B2 mgmt key
-export B2_APPLICATION_KEY=...
+unset AWS_PROFILE                       # stop the AWS SDK using a shared-config profile
+export TF_VAR_state_passphrase=...      # = TF_STATE_PASSPHRASE
+export B2_APPLICATION_KEY_ID=...        # b2 provider: B2 mgmt key (keyID)
+export B2_APPLICATION_KEY=...           # b2 provider: B2 mgmt key (appKey)
+export AWS_ACCESS_KEY_ID=$B2_APPLICATION_KEY_ID      # s3 backend: same B2 keyID
+export AWS_SECRET_ACCESS_KEY=$B2_APPLICATION_KEY     # s3 backend: same B2 appKey
 tofu init
-tofu plan                              # must be a CLEAN no-op for B2 buckets
+tofu plan                               # must be a CLEAN no-op for B2 buckets
 ```
 
 Get the bucket IDs to fill `import` blocks:

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,78 @@
+# terraform/ — OpenTofu for the external/cloud gap
+
+OpenTofu (`tofu`, **not** Terraform) manages **only** the external/cloud + bootstrap "gap":
+B2 buckets/keys, DNS, Tailscale, Authentik, and the *structure* of Infisical. Every
+in-cluster workload stays owned by Helm + `.github/workflows/ci.yml` — unchanged.
+
+**This is Phase 0 (skeleton) + Phase 1 (B2 import), plan-only.** End state: `tofu plan`
+is a clean no-op over the live B2 buckets. No resources created, none destroyed.
+
+Region for everything: **`ca-east-006`**.
+
+## Scope boundary
+
+- TF **owns**: B2, DNS, Tailscale, Authentik, Infisical structure, node labels (Phase 5).
+- TF **never touches**: `helm_release`, workload `kubernetes` resources, `charts/**`, `ci.yml`.
+- Secret **values** live in Infisical; TF owns containers/access only. Bucket *names* are
+  non-secret values; bucket *keys* are Infisical secrets.
+
+## Tier-0 seeded roots (the DR recovery root)
+
+These are the **only** hand-made credentials; everything downstream is TF-managed. They live
+in the **password manager** + **GitHub Actions secrets** — never in state, never in Infisical.
+Because Infisical runs *in the cluster*, full DR cannot bootstrap from Infisical — **the
+password manager is the true recovery root.**
+
+1. **B2 management app key** — account-wide create/list buckets+keys. GH secrets
+   `B2_APPLICATION_KEY_ID` / `B2_APPLICATION_KEY` (reused for both the s3 backend and the b2 provider).
+2. **State bucket `homelab-tofu-state-dd43bf5b`** — made by hand (private, `ca-east-006`).
+   Can't be TF-managed: it stores the state that would manage it.
+3. **`TF_STATE_PASSPHRASE`** — PBKDF2 passphrase for native state encryption. GH secret +
+   PM. **Not in Infisical** (state holds Infisical creds). Injected as `TF_VAR_state_passphrase`.
+4. **Infisical bootstrap machine identity** (Universal Auth) — `INFISICAL_CLIENT_ID` /
+   `INFISICAL_CLIENT_SECRET` in GH secrets + PM. Not consumed by this B2-only PR (seeded for
+   Phase 3). **Not in Infisical**, never in state.
+
+Already-existing GH secrets reused later: `KUBE_CONFIG`, `TS_OAUTH_CLIENT_ID`, `TS_OAUTH_SECRET`.
+
+## Bootstrap order (§7)
+
+```
+0. (manual, DONE) B2 mgmt key + hand-made state bucket homelab-tofu-state-dd43bf5b.
+1. (manual, DONE) Infisical bootstrap machine identity.
+2. (manual, DONE) Seed the 4 Tier-0 secrets into GH Actions + password manager.
+3. tofu init            # backend = hand-made encrypted state bucket
+4. fill real bucket IDs in import blocks (main.tf), then tofu plan  <-- this PR
+5. (later) tofu apply for app keys / dns / tailscale / authentik / node labels
+```
+
+## Running
+
+```bash
+cd terraform
+export TF_VAR_state_passphrase=...     # = TF_STATE_PASSPHRASE
+export B2_APPLICATION_KEY_ID=...       # B2 mgmt key
+export B2_APPLICATION_KEY=...
+tofu init
+tofu plan                              # must be a CLEAN no-op for B2 buckets
+```
+
+Get the bucket IDs to fill `import` blocks:
+
+```bash
+b2 list-buckets            # bucketId is the `id =` value (NOT the name)
+```
+
+restic's bucket name is confirmed from Infisical `/backup/restic` -> `RESTIC_REPOSITORY`.
+
+## Locking
+
+B2's S3 API has no DynamoDB-style locking. **Mitigation: serialize applies through CI**
+(`concurrency: { group: terraform, cancel-in-progress: false }`). **Never run `tofu apply`
+locally** while CI might — one human + one runner = no contention if you don't race them.
+
+## HARD STOP rule (import safety)
+
+After import, if `tofu plan` shows ANY `destroy`/replace on a live bucket, **do not apply** —
+orphaning a backup bucket loses backups. Fix module HCL (lifecycle/retention/`bucket_info`
+to match live) until the plan is a clean no-op / in-place-only update, then merge.

--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -1,0 +1,37 @@
+terraform {
+  # State lives in the hand-made (Tier-0) B2 bucket via the S3-compatible endpoint.
+  # B2 creds come from env: B2_APPLICATION_KEY_ID / B2_APPLICATION_KEY (reuse the mgmt key).
+  backend "s3" {
+    bucket = "homelab-tofu-state-dd43bf5b"
+    key    = "global/terraform.tfstate"
+    region = "ca-east-006"
+
+    endpoints = {
+      s3 = "https://s3.ca-east-006.backblazeb2.com"
+    }
+
+    # B2's S3 API is not AWS — skip AWS-specific validation/metadata calls.
+    skip_credentials_validation = true
+    skip_region_validation      = true
+    skip_requesting_account_id  = true
+    skip_metadata_api_check     = true
+    use_path_style              = true
+  }
+
+  # OpenTofu native state encryption (PBKDF2/AES-GCM). Passphrase is a Tier-0 root
+  # (TF_VAR_state_passphrase) — never in Infisical, since state holds Infisical creds.
+  encryption {
+    key_provider "pbkdf2" "k" {
+      passphrase = var.state_passphrase
+    }
+    method "aes_gcm" "m" {
+      keys = key_provider.pbkdf2.k
+    }
+    state {
+      method = method.aes_gcm.m
+    }
+    plan {
+      method = method.aes_gcm.m
+    }
+  }
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,37 @@
+# Module wiring. Phase 1 = B2 only. Later phases attach their modules below.
+
+module "b2" {
+  source = "./modules/b2"
+}
+
+# Phase 2: module "tailscale"        { source = "./modules/tailscale" }
+# Phase 3: module "infisical_platform" { source = "./modules/infisical-platform" }
+# Phase 4: module "authentik"        { source = "./modules/authentik" }
+# Phase 5: module "cluster_bootstrap" { source = "./modules/cluster-bootstrap" }
+# DNS:     module "dns"              { source = "./modules/dns" }
+
+# ---------------------------------------------------------------------------
+# Declarative import (OpenTofu 1.6+): adopt the existing live B2 buckets into
+# state WITHOUT recreating them. Plan-only this PR — must be a clean no-op.
+#
+# IDs are B2 bucket IDs (NOT names). Fill from `b2 list-buckets` before plan.
+# restic's bucket is confirmed from Infisical /backup/restic -> RESTIC_REPOSITORY.
+#
+# HARD STOP: if `tofu plan` shows ANY destroy/replace on a bucket, do not apply.
+# Fix module HCL (lifecycle/retention/bucket_info) to match live, then re-plan.
+# ---------------------------------------------------------------------------
+
+import {
+  to = module.b2.b2_bucket.homelab_backups
+  id = "REPLACE_WITH_BUCKET_ID_homelab-backups-431118"
+}
+
+import {
+  to = module.b2.b2_bucket.open_archiver
+  id = "REPLACE_WITH_BUCKET_ID_open-archiver-homelab"
+}
+
+import {
+  to = module.b2.b2_bucket.restic
+  id = "REPLACE_WITH_BUCKET_ID_homelab-k3s-567f18"
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -23,15 +23,15 @@ module "b2" {
 
 import {
   to = module.b2.b2_bucket.homelab_backups
-  id = "REPLACE_WITH_BUCKET_ID_homelab-backups-431118"
+  id = "0a041ee91bcea84291a2011d" # homelab-backups-431118
 }
 
 import {
   to = module.b2.b2_bucket.open_archiver
-  id = "REPLACE_WITH_BUCKET_ID_open-archiver-homelab"
+  id = "1ae40e29cbdec82291e2011d" # open-archiver-homelab
 }
 
 import {
   to = module.b2.b2_bucket.restic
-  id = "REPLACE_WITH_BUCKET_ID_homelab-k3s-567f18"
+  id = "5ad4be49abae28a291a2011d" # homelab-k3s-567f18
 }

--- a/terraform/modules/b2/main.tf
+++ b/terraform/modules/b2/main.tf
@@ -1,0 +1,58 @@
+# One b2_bucket per REAL live bucket (live state corrected from spec's assumed 4).
+#
+#   resource              live bucket name          region        used by
+#   --------              ----------------          ------        -------
+#   homelab_backups   ->  homelab-backups-431118    ca-east-006   immich-db / home-assistant / authentik backups (SHARED)
+#   open_archiver     ->  open-archiver-homelab     ca-east-006   open-archiver
+#   restic            ->  homelab-k3s-567f18        ca-east-006   restic-backup
+#
+# All bucket_type allPrivate. Imported via `import` blocks in ../../main.tf.
+# IMPORTANT: if `tofu plan` post-import shows destroy/replace, the culprit is
+# almost always lifecycle_rules / bucket_info differing from live — set them
+# here to match what `b2 get-bucket <name>` reports, then re-plan.
+
+resource "b2_bucket" "homelab_backups" {
+  bucket_name = "homelab-backups-431118"
+  bucket_type = "allPrivate"
+
+  # lifecycle_rules / bucket_info: add to match live if plan is not a clean no-op.
+}
+
+resource "b2_bucket" "open_archiver" {
+  bucket_name = "open-archiver-homelab"
+  bucket_type = "allPrivate"
+
+  # lifecycle_rules / bucket_info: add to match live if plan is not a clean no-op.
+}
+
+resource "b2_bucket" "restic" {
+  bucket_name = "homelab-k3s-567f18"
+  bucket_type = "allPrivate"
+
+  # lifecycle_rules / bucket_info: add to match live if plan is not a clean no-op.
+}
+
+# ---------------------------------------------------------------------------
+# DEFERRED: app keys — apply in a follow-up rotation PR.
+# B2 never re-returns a key's secret, so existing keys CANNOT be imported, and
+# creating new keys is a CREATE (violates this PR's plan-only no-op). Resources
+# are sketched below and intentionally commented out until the rotation PR.
+# ---------------------------------------------------------------------------
+#
+# resource "b2_application_key" "homelab_backups" {
+#   key_name     = "homelab-backups-rw"
+#   bucket_id    = b2_bucket.homelab_backups.bucket_id
+#   capabilities = ["listBuckets", "listFiles", "readFiles", "writeFiles", "deleteFiles"]
+# }
+#
+# resource "b2_application_key" "open_archiver" {
+#   key_name     = "open-archiver-rw"
+#   bucket_id    = b2_bucket.open_archiver.bucket_id
+#   capabilities = ["listBuckets", "listFiles", "readFiles", "writeFiles", "deleteFiles"]
+# }
+#
+# resource "b2_application_key" "restic" {
+#   key_name     = "restic-rw"
+#   bucket_id    = b2_bucket.restic.bucket_id
+#   capabilities = ["listBuckets", "listFiles", "readFiles", "writeFiles", "deleteFiles"]
+# }

--- a/terraform/modules/b2/main.tf
+++ b/terraform/modules/b2/main.tf
@@ -15,7 +15,11 @@ resource "b2_bucket" "homelab_backups" {
   bucket_name = "homelab-backups-431118"
   bucket_type = "allPrivate"
 
-  # lifecycle_rules / bucket_info: add to match live if plan is not a clean no-op.
+  # Live bucket has SSE-B2 enabled — declare it to match, else plan disables it.
+  default_server_side_encryption {
+    mode      = "SSE-B2"
+    algorithm = "AES256"
+  }
 }
 
 resource "b2_bucket" "open_archiver" {

--- a/terraform/modules/b2/outputs.tf
+++ b/terraform/modules/b2/outputs.tf
@@ -1,0 +1,17 @@
+output "bucket_names" {
+  description = "Map of logical name -> live B2 bucket name."
+  value = {
+    homelab_backups = b2_bucket.homelab_backups.bucket_name
+    open_archiver   = b2_bucket.open_archiver.bucket_name
+    restic          = b2_bucket.restic.bucket_name
+  }
+}
+
+output "bucket_ids" {
+  description = "Map of logical name -> live B2 bucket ID."
+  value = {
+    homelab_backups = b2_bucket.homelab_backups.bucket_id
+    open_archiver   = b2_bucket.open_archiver.bucket_id
+    restic          = b2_bucket.restic.bucket_id
+  }
+}

--- a/terraform/modules/b2/variables.tf
+++ b/terraform/modules/b2/variables.tf
@@ -1,0 +1,3 @@
+# No input variables yet. Buckets are modeled as discrete resources in main.tf
+# (one resource per real live bucket) rather than a generated map, so each can
+# carry its own lifecycle/retention attributes to match live reality on import.

--- a/terraform/modules/b2/versions.tf
+++ b/terraform/modules/b2/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    b2 = {
+      source  = "Backblaze/b2"
+      version = "~> 0.10"
+    }
+  }
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,9 @@
+output "b2_bucket_names" {
+  description = "Live B2 bucket names managed by TF."
+  value       = module.b2.bucket_names
+}
+
+output "b2_bucket_ids" {
+  description = "Live B2 bucket IDs managed by TF."
+  value       = module.b2.bucket_ids
+}

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -1,0 +1,2 @@
+# Credentials from env: B2_APPLICATION_KEY_ID / B2_APPLICATION_KEY (the Tier-0 mgmt key).
+provider "b2" {}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,5 @@
+variable "state_passphrase" {
+  description = "PBKDF2 passphrase for native state encryption. Tier-0 root; set via TF_VAR_state_passphrase (GH secret TF_STATE_PASSPHRASE). Never in Infisical."
+  type        = string
+  sensitive   = true
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,12 @@
+terraform {
+  # >= 1.7.0: native state encryption GA'd in 1.7; declarative `import` blocks 1.6+.
+  required_version = ">= 1.7.0"
+
+  required_providers {
+    b2 = {
+      source  = "Backblaze/b2"
+      version = "~> 0.10"
+    }
+    # Other providers (dns, tailscale, authentik, infisical, kubernetes) added in later phases.
+  }
+}


### PR DESCRIPTION
## Summary

Introduces **OpenTofu** to manage only the external/cloud "gap", starting with **B2 buckets**. Helm + `ci.yml` keep owning every `charts/**` workload, unchanged. This is **Phase 0 skeleton + Phase 1 B2 import** — no live resource created or destroyed; import into state happens on apply-on-merge.

Boundary: **TF = external gap (B2/DNS/Tailscale/Authentik/Infisical structure); Helm = all workloads.**

## What's here

- `terraform/`: versions (OpenTofu ≥1.7, b2 ~0.10), s3 backend → `homelab-tofu-state-dd43bf5b` @ `ca-east-006` with native PBKDF2/AES-GCM state encryption, b2 provider, b2 module wiring + declarative `import` blocks (real bucket IDs).
- `modules/b2/`: 3 real live buckets — shared `homelab-backups-431118`, `open-archiver-homelab`, `homelab-k3s-567f18`. SSE-B2 declared on the shared bucket to match live. **App keys deferred** (commented) to a follow-up rotation PR — B2 won't re-return key secrets, so they can't be imported.
- `.github/workflows/terraform.yml`: separate workflow, plan-on-PR (comment) + apply-on-merge gated by `terraform-prod` environment + `concurrency: terraform`.
- `ci.yml`: `paths-ignore: ['terraform/**']` so Helm CI skips TF-only changes.
- `.gitignore` (+`*.tfplan`/`*.tfvars`), `CLAUDE.md` (boundary doc).

## Verified plan (clean no-op)

```
Plan: 3 to import, 0 to add, 0 to change, 0 to destroy.
```

Zero destroy/replace on any live bucket — HARD STOP rule satisfied.

## Before merge (operator)

- [x] GH Actions secrets exist: `TF_STATE_PASSPHRASE`, `B2_APPLICATION_KEY_ID`, `B2_APPLICATION_KEY`.
- [x] GitHub Environment `terraform-prod` created with required reviewer = operator.
- [x] PR plan job reproduces the clean no-op on the runner.

Apply-on-merge performs the state import (still no live mutation).

https://claude.ai/code/session_01H5j7vJFA2Y5XTj2jgKLoGg