### PR TITLE
feat(homelab-mcp): add internal MCP server + wire LibreChat

### DIFF
--- a/charts/homelab-mcp/Chart.yaml
+++ b/charts/homelab-mcp/Chart.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v2
+name: homelab-mcp
+description: Homelab MCP server (FastMCP, streamable-http) — Home Assistant tools for LibreChat
+type: application
+version: 0.1.0
+# appVersion tracks the pinned image tag (sha-<short>). sha-72e314e fixes the
+# image's builder/runtime Python mismatch (3.13 venv under a 3.14 runtime →
+# ModuleNotFoundError: app) by aligning the runtime base to python:3.13.
+appVersion: "sha-72e314e"
+maintainers:
+  - name: homelab

--- a/charts/homelab-mcp/templates/_helpers.tpl
+++ b/charts/homelab-mcp/templates/_helpers.tpl
@@ -1,0 +1,49 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "homelab-mcp.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "homelab-mcp.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "homelab-mcp.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "homelab-mcp.labels" -}}
+helm.sh/chart: {{ include "homelab-mcp.chart" . }}
+{{ include "homelab-mcp.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "homelab-mcp.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "homelab-mcp.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/homelab-mcp/templates/deployment.yaml
+++ b/charts/homelab-mcp/templates/deployment.yaml
@@ -1,0 +1,90 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "homelab-mcp.fullname" . }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "homelab-mcp.labels" . | nindent 4 }}
+    component: app
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "homelab-mcp.selectorLabels" . | nindent 6 }}
+      component: app
+  template:
+    metadata:
+      labels:
+        {{- include "homelab-mcp.selectorLabels" . | nindent 8 }}
+        component: app
+    spec:
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: homelab-mcp
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            # Image USER is the named user `app` (UID 10001 per its Dockerfile).
+            # runAsNonRoot can't verify a non-numeric user, so pin the UID.
+            runAsUser: 10001
+            runAsGroup: 10001
+            capabilities:
+              drop:
+                - ALL
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          env:
+            - name: APP_TRANSPORT
+              value: {{ .Values.app.transport | quote }}
+            - name: APP_HOST
+              value: "0.0.0.0"
+            - name: APP_PORT
+              value: {{ .Values.service.port | quote }}
+            {{- range $envName, $secretKey := .Values.existingSecret.keys }}
+            - name: {{ $envName }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $.Values.existingSecret.name }}
+                  key: {{ $secretKey }}
+            {{- end }}
+            {{- range $key, $value := .Values.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+          startupProbe:
+            httpGet:
+              path: /health
+              port: http
+            failureThreshold: 30
+            periodSeconds: 2
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            # Image needs a writable /tmp (readOnlyRootFilesystem: true).
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/charts/homelab-mcp/templates/infisical-secret.yaml
+++ b/charts/homelab-mcp/templates/infisical-secret.yaml
@@ -1,0 +1,38 @@
+{{- /*
+InfisicalSecret CR — sole secret source for this chart (no sealed-secrets).
+The operator pulls secrets from Infisical (folder /homelab-mcp) and
+materializes the `homelab-mcp-secrets` Secret consumed by the deployment via
+secretKeyRef. See docs/runbooks/INFISICAL_MIGRATION.md.
+*/ -}}
+{{- if .Values.infisical.enabled }}
+apiVersion: secrets.infisical.com/v1alpha1
+kind: InfisicalSecret
+metadata:
+  name: homelab-mcp-infisical
+  labels:
+    app: homelab-mcp
+spec:
+  hostAPI: {{ .Values.infisical.hostAPI | quote }}
+  syncConfig:
+    resyncInterval: {{ .Values.infisical.resyncInterval | quote }}
+    instantUpdates: {{ .Values.infisical.instantUpdates }}
+  authentication:
+    universalAuth:
+      secretsScope:
+        projectSlug: {{ .Values.infisical.projectSlug | quote }}
+        envSlug: {{ .Values.infisical.envSlug | quote }}
+        secretsPath: {{ .Values.infisical.secretsPath | quote }}
+      credentialsRef:
+        secretName: {{ .Values.infisical.credentialsRef.secretName | quote }}
+        secretNamespace: {{ .Values.infisical.credentialsRef.secretNamespace | quote }}
+  managedKubeSecretReferences:
+    - secretName: {{ .Values.existingSecret.name }}
+      secretNamespace: {{ .Release.Namespace }}
+      creationPolicy: "Owner"
+      secretType: Opaque
+      template:
+        includeAllSecrets: false
+        data:
+          auth-token: '{{ `{{ (index . "auth-token").Value }}` }}'
+          home-assistant-token: '{{ `{{ (index . "home-assistant-token").Value }}` }}'
+{{- end }}

--- a/charts/homelab-mcp/templates/networkpolicy.yaml
+++ b/charts/homelab-mcp/templates/networkpolicy.yaml
@@ -1,0 +1,45 @@
+{{- /*
+Internal-only isolation. Ingress on :8000 restricted to LibreChat pods (the
+sole consumer) plus the monitoring namespace for unauthenticated /metrics.
+Egress left permissive: home-assistant is host-network on pi4-02, reached via
+node IP rather than a pod selector, so a tight egress rule would break it.
+Only effective under a default-deny baseline / NetworkPolicy-enforcing CNI.
+*/ -}}
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "homelab-mcp.fullname" . }}-network-policy
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "homelab-mcp.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "homelab-mcp.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # MCP (:8000) — only LibreChat pods may reach the server.
+    - ports:
+        - protocol: TCP
+          port: {{ .Values.service.port }}
+      from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: librechat
+        # Metrics scraping from the monitoring namespace (/metrics is open).
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: monitoring
+  egress:
+    # DNS resolution.
+    - ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # Permissive egress (HA host-network reached via node IP).
+    - {}
+{{- end }}

--- a/charts/homelab-mcp/templates/service.yaml
+++ b/charts/homelab-mcp/templates/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "homelab-mcp.fullname" . }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "homelab-mcp.labels" . | nindent 4 }}
+    component: app
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "homelab-mcp.selectorLabels" . | nindent 4 }}
+    component: app

--- a/charts/homelab-mcp/values.yaml
+++ b/charts/homelab-mcp/values.yaml
@@ -1,0 +1,68 @@
+---
+namespace: default
+
+image:
+  repository: ghcr.io/jcserv/homelab-mcp
+  # sha-72e314e: multi-arch (amd64+arm64), fixes the Python 3.13/3.14
+  # builder-runtime mismatch that crashed earlier tags. Repo convention =
+  # pin a sha-<short> tag, never :latest.
+  tag: "sha-72e314e"
+  pullPolicy: IfNotPresent
+
+replicaCount: 1
+
+service:
+  type: ClusterIP
+  port: 8000
+
+# MCP transport. Server speaks streamable-http on :8000 (/mcp bearer-gated,
+# /health + /metrics unauthenticated).
+app:
+  transport: streamable-http
+
+# Plain (non-secret) app environment. Secret-sourced env comes from
+# existingSecret.keys below.
+env:
+  # home-assistant runs host-network on pi4-02 but exposes a ClusterIP Service.
+  # Pods resolve cluster Service DNS, not *.jarrodservilla.com.
+  APP_HOME_ASSISTANT_BASE_URL: http://home-assistant.default.svc.cluster.local:8123
+  # Writes ON (confirmed). lock.unlock stays gated off.
+  APP_HA_ENABLE_WRITES: "true"
+  APP_HA_ENABLE_UNLOCK: "false"
+
+# Env vars sourced from the Infisical-managed Secret via secretKeyRef.
+existingSecret:
+  name: homelab-mcp-secrets
+  keys:
+    APP_AUTH_TOKEN: auth-token
+    APP_HOME_ASSISTANT_TOKEN: home-assistant-token
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 64Mi
+  limits:
+    cpu: 500m
+    memory: 256Mi
+
+# Restrict ingress on :8000 to LibreChat pods (effective only under a
+# default-deny baseline / CNI that enforces NetworkPolicy). Egress left
+# permissive (HA is host-network → reached via node IP, not a pod selector).
+networkPolicy:
+  enabled: true
+
+# Infisical Secrets Operator — sole secret source for this chart (no
+# sealed-secrets). Folder /homelab-mcp in project homelab-nkcl, env prod.
+infisical:
+  enabled: true
+  # In-cluster Service URL — public hostname only resolves via pihole DNS,
+  # which CoreDNS can't reach. Keeps operator traffic in-cluster.
+  hostAPI: http://infisical-infisical-standalone-infisical.default.svc.cluster.local:8080/api
+  resyncInterval: 60s
+  instantUpdates: false
+  projectSlug: homelab-nkcl
+  envSlug: prod
+  secretsPath: /homelab-mcp
+  credentialsRef:
+    secretName: infisical-machine-identity
+    secretNamespace: infisical-secrets-operator

--- a/charts/librechat/Chart.yaml
+++ b/charts/librechat/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: librechat
 description: LibreChat - self-hosted multi-model AI chat UI
 type: application
-version: 1.0.1
+version: 1.0.2
 appVersion: "v0.8.7-rc1"
 maintainers:
   - name: homelab

--- a/charts/librechat/templates/infisical-secret.yaml
+++ b/charts/librechat/templates/infisical-secret.yaml
@@ -40,4 +40,9 @@ spec:
           JWT_REFRESH_SECRET: '{{ `{{ (index . "jwt-refresh-secret").Value }}` }}'
           MEILI_MASTER_KEY: '{{ `{{ (index . "meili-master-key").Value }}` }}'
           OPENROUTER_KEY: '{{ `{{ (index . "openrouter-key").Value }}` }}'
+          # Full Authorization header for the homelab MCP server. The raw token
+          # (Infisical key HOMELAB_MCP_TOKEN) must equal /homelab-mcp auth-token;
+          # the "Bearer " prefix is composed here because LibreChat substitutes
+          # only a whole-string ${VAR} into the header value, not inline.
+          HOMELAB_MCP_AUTH_HEADER: 'Bearer {{ `{{ (index . "HOMELAB_MCP_TOKEN").Value }}` }}'
 {{- end }}

--- a/charts/librechat/values.yaml
+++ b/charts/librechat/values.yaml
@@ -67,11 +67,35 @@ librechat:
       SEARCH: "true"
       USE_REDIS: "true"
       REDIS_URI: redis://valkey.default.svc.cluster.local:6379/2
-    # librechat.yaml — defines the OpenRouter custom endpoint. Phase 2 (MCP
-    # server) adds an `mcpServers:` block here.
+    # librechat.yaml — defines the OpenRouter custom endpoint + the homelab MCP
+    # server (Home Assistant tools, in-cluster via Service DNS). HOMELAB_MCP_TOKEN
+    # is injected via the librechat-credentials-env Secret (Infisical /librechat)
+    # and must match /homelab-mcp auth-token.
     configYamlContent: |
       version: 1.2.1
       cache: true
+      # The MCP server is reached over in-cluster Service DNS, which resolves to
+      # a private ClusterIP. LibreChat's SSRF guard blocks private targets unless
+      # the host is allowlisted here.
+      mcpSettings:
+        allowedDomains:
+          - homelab-mcp.default.svc.cluster.local
+      mcpServers:
+        homelab:
+          type: streamable-http
+          url: http://homelab-mcp.default.svc.cluster.local:8000/mcp
+          # Skip the app-level startup inspection: it sends header placeholders
+          # raw (no env substitution), so the server's 401 would mis-classify
+          # this as requiresOAuth. With startup:false the connection is made
+          # per-user, where processMCPEnv substitutes the header correctly.
+          startup: false
+          headers:
+            # LibreChat's extractEnvVariable only substitutes a whole-string
+            # ${VAR}, not inline after "Bearer ". So HOMELAB_MCP_AUTH_HEADER
+            # holds the full "Bearer <token>" string (composed in the
+            # InfisicalSecret template).
+            Authorization: "${HOMELAB_MCP_AUTH_HEADER}"
+          timeout: 60000
       endpoints:
         custom:
           - name: "OpenRouter"


### PR DESCRIPTION
## Summary

Stands up **homelab-mcp** internal-only (ClusterIP, no ingress) — a FastMCP server exposing Home Assistant tools, consumed by LibreChat over Service DNS. Completes the LibreChat "Phase 2" MCP hook. Secrets come solely from Infisical; HA **writes enabled** (`lock.unlock` stays gated off).

## Changes

**New chart `charts/homelab-mcp/`** (modeled on `open-archiver`):
- Image pinned to `sha-72e314e` (multi-arch amd64+arm64). Earlier candidates were unbuilt (`sha-7b260a9`) or had a Python 3.13/3.14 builder-runtime mismatch (`sha-18ea9ef`).
- `runAsNonRoot` + `runAsUser: 10001` (image's named `app` user can't be verified non-root otherwise), `readOnlyRootFilesystem` + emptyDir `/tmp`, `/health` probes.
- `InfisicalSecret` → `homelab-mcp-secrets` (`auth-token`, `home-assistant-token`).
- NetworkPolicy: ingress `:8000` from LibreChat pods + monitoring; permissive egress (HA is host-network, reached via node IP).

**LibreChat (`charts/librechat/`)**:
- `mcpServers.homelab` (streamable-http) + `mcpSettings.allowedDomains` (SSRF guard allowlist for the internal `.svc.cluster.local` host).
- `startup: false` so the server connects per-user — the app-level startup inspection sends header placeholders raw and would mis-classify the 401 as `requiresOAuth`.
- Compose `HOMELAB_MCP_AUTH_HEADER` (`Bearer <token>`) in the InfisicalSecret template; LibreChat substitutes only a whole-string `${VAR}`, not inline after `Bearer `.

## Verification

Deployed to the cluster and verified end to end:
- homelab-mcp `1/1 Running`; `/health` → `200` with `home_assistant: up:true`.
- `/mcp` → `401` without token, `200` MCP handshake with token.
- LibreChat connects per-user and the `homelab` HA tools resolve.

## Manual prerequisites (already done in cluster)

Infisical `homelab-nkcl`/`prod`: folder `/homelab-mcp` (`auth-token`, `home-assistant-token`); folder `/librechat` key `HOMELAB_MCP_TOKEN` (same value as `auth-token`). The ghcr image package was made public (cluster has no pull secret).

https://claude.ai/code/session_01FV7uwwSDz8KhNfKC8oU3f5