### PR TITLE
feat(terraform): Tailscale OpenTofu module (Phase 2)

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -25,6 +25,11 @@ env:
   # standard AWS env vars (NOT the B2_ ones). Same Tier-0 B2 mgmt key, AWS-named.
   AWS_ACCESS_KEY_ID: ${{ secrets.B2_APPLICATION_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.B2_APPLICATION_KEY }}
+  # tailscale provider creds: NEW ACL-scoped OAuth client (scopes: acl write,
+  # auth_keys, devices:core write). Distinct from the node-auth TS_OAUTH_*.
+  # The provider hits public api.tailscale.com — no cluster VPN needed.
+  TAILSCALE_OAUTH_CLIENT_ID: ${{ secrets.TS_TF_OAUTH_CLIENT_ID }}
+  TAILSCALE_OAUTH_CLIENT_SECRET: ${{ secrets.TS_TF_OAUTH_CLIENT_SECRET }}
 
 jobs:
   plan:

--- a/docs/terraform-architecture-scoping.md
+++ b/docs/terraform-architecture-scoping.md
@@ -1,0 +1,225 @@
+# Terraform / OpenTofu Architecture Scoping — homelab-k8s
+
+**Status:** Proposal / scoping document
+**Author:** Platform architecture review
+**Date:** 2026-06-23
+**Decision:** **OpenTofu** (not Terraform). See §2.
+
+---
+
+## Executive summary
+
+Introduce OpenTofu to manage *only* the external/cloud and bootstrap "gap" — Backblaze B2 buckets & keys, DNS records, Tailscale ACLs/tags, Authentik OAuth apps/groups, and the **structure** of the Infisical platform (folders, machine identities, access policies) — while the working Helm + GitHub Actions pipeline keeps owning every in-cluster workload untouched. This is high-value because those resources are today click-ops, undocumented, and the single most likely thing to be unrecoverable after a laptop/account loss, whereas the Helm pipeline already gives you GitOps reviewability for workloads. The hard problem is not the Terraform itself but two bootstrap loops: state lives in B2 but B2 keys could be TF-managed, and TF manages Infisical but needs an Infisical identity to read secrets — both are solved by a small, documented set of manually-seeded root credentials. Do **not** put Helm releases or Kubernetes workload manifests under OpenTofu; that would fork your deployment model for no gain.
+
+**Recommendation: PARTIAL-GO.** Adopt OpenTofu for the external-resource gap in phases, starting with B2 + DNS (read-mostly, import-friendly, disaster-recovery payoff). Explicitly *exclude* the `helm` and most of the `kubernetes` provider surface. If after Phase 1 the maintenance tax outweighs the documentation value, stop — the phases are independent.
+
+---
+
+## 1. Scope boundary
+
+**OpenTofu OWNS (the gap):**
+
+| Domain | Concrete resources | Why TF |
+|---|---|---|
+| Backblaze B2 | `b2_bucket` (restic, immich-db, ha, open-archiver), `b2_application_key` scoped per-bucket | Click-ops today; lifecycle + retention rules belong in code; DR-critical |
+| DNS | per-record `*.jarrodservilla.com` (A/AAAA/CNAME for ingress hostnames) | Currently hand-edited; drift-prone; trivially declarative |
+| Tailscale | `tailscale_acl`, `tailscale_tailnet_key` (CI auth key rotation), device `tags` | ACL is already a JSON document — natural fit; CI auth path is security-sensitive |
+| Authentik | `authentik_application`, `authentik_provider_oauth2`, `authentik_group`, scope mappings | OAuth wiring for Grafana/others is invisible config; recreating by hand is error-prone |
+| Infisical **structure** | `infisical_project`, folders, `infisical_identity` (machine), `infisical_identity_*_auth`, access policies | Defines the secret platform's shape — see §5. TF owns *structure*, never *values* |
+| Cluster node metadata | node labels `zigbee=true` (pi4-02), `storage=true` (pi5-01) via narrow `kubernetes_labels` | Bootstrap concern, today undocumented tribal knowledge; tiny, safe k8s surface |
+
+**Helm/CI KEEPS (unchanged):**
+
+- All `charts/**` workloads, including infra charts (metallb, cert-manager, nginx-ingress, sealed-secrets, network-policies), monitoring, apps, backup CronJobs.
+- `helm upgrade --install` driven by `git diff HEAD~1` in `.github/workflows/ci.yml`.
+- Namespace derivation from `values.yaml`, `values/network.yaml` globals, `values.local.yaml` overlays.
+
+**Ambiguous — ruled on explicitly:**
+
+- **Helm releases via the `helm` provider → NO.** You already have a working, reviewable Helm deploy path. Wrapping it in `helm_release` forks the source of truth (Chart.lock vs TF state), breaks the `git diff` deploy trigger, and adds a state dependency to every workload change. Not worth it for a single operator.
+- **`kubernetes` provider → MINIMAL ONLY.** Node labels qualify (bootstrap, not workload, and not expressible in Helm). Do **not** use it for namespaces, CRDs, or RBAC that charts already create. Drawing this line tightly is what keeps the two systems from colliding.
+- **MetalLB IP pool values → STAYS IN HELM.** `values/network.yaml` is already the single source of truth (per `docs/runbooks/ISP_MIGRATION.md`). Don't split network config across two tools.
+- **B2 buckets for backups vs. the *backup schedules* (CronJobs)** → bucket+key in TF, CronJob in Helm. The seam is the bucket name + key, passed as a non-secret value (bucket name) and an Infisical secret (key).
+
+---
+
+## 2. Provider selection — **OpenTofu over Terraform**
+
+**Why OpenTofu:** MPL-licensed, no BUSL rug-pull risk, drop-in CLI (`tofu`), native **state encryption** (see §3) which Terraform lacks without external tooling — directly relevant given state sits next to secrets. For a hobbyist repo there is zero downside and one concrete feature win.
+
+| Provider | Source | Maturity / maintenance risk | ARM64 / runner notes |
+|---|---|---|---|
+| B2 | `Backblaze/b2` | Official, stable, low risk | Provider binary runs on the **runner**, not the Pis — `linux/amd64` GitHub runner fine. Wraps the B2 Go SDK |
+| DNS | depends on registrar (see assumption) — `cloudflare/cloudflare` if CF | CF provider: very mature. Generic `hashicorp/dns` (RFC2136) only if you self-host DNS | amd64 runner; no Pi involvement |
+| Tailscale | `tailscale/tailscale` | Official, active | amd64 runner; needs OAuth client or API key (you already use TS OAuth in CI) |
+| Authentik | `goauthentik/authentik` | Vendor-maintained, tracks server version — **pin provider to your Authentik version** | amd64 runner; talks to Authentik API over Tailscale/ingress |
+| Infisical | `Infisical/infisical` | Newer, smaller; **highest maintenance risk** of the set — pin tightly, expect breaking changes | amd64 runner; talks to self-hosted Infisical API |
+| Kubernetes | `hashicorp/kubernetes` | Mature | **Used minimally** (node labels). Runs from runner over Tailscale via existing kubeconfig |
+
+**No provider runs on the ARM64 Pis** — OpenTofu executes on the GitHub Actions amd64 runner (or your laptop). ARM64 only matters if you `tofu` from a Pi, which you shouldn't.
+
+**Assumptions flagged:** DNS registrar unknown (assuming Cloudflare — *confirm*); B2 region unknown; Tailscale tier (ACL-as-code via API needs the OAuth client you already have — assuming current tier supports it); Authentik version unknown (*pin provider to match*); **Infisical assumed self-hosted in-cluster** (evidence: `charts/infisical`, `.infisical.json`) — this drives the bootstrap loop in §7.
+
+---
+
+## 3. State management
+
+**Backend: B2 via the S3-compatible endpoint** (`s3` backend with `endpoints.s3` override). You already pay for B2; a dedicated `tofu-state` bucket costs pennies.
+
+```hcl
+terraform {
+  backend "s3" {
+    bucket                      = "homelab-tofu-state"
+    key                         = "global/terraform.tfstate"
+    region                      = "us-west-004"            # ASSUMPTION: confirm B2 region
+    endpoints = { s3 = "https://s3.us-west-004.backblazeb2.com" }
+    skip_credentials_validation = true
+    skip_region_validation      = true
+    skip_requesting_account_id  = true
+    skip_metadata_api_check     = true
+    use_path_style              = true
+  }
+}
+```
+
+**Locking — the real limitation:** B2's S3 API does **not** support DynamoDB-style locking, and OpenTofu's S3 backend lockfile support depends on conditional-write semantics B2 historically lacked. **Mitigation for a single operator: serialize applies through CI** (one workflow, concurrency group `terraform`) so two applies never race. With exactly one human and one CI runner, lock contention is a non-issue if you never run `apply` locally and in CI simultaneously. Document this; don't engineer around a problem you don't have.
+
+**Encryption (the reason for OpenTofu):** Enable OpenTofu **native state encryption** with a PBKDF2/AES-GCM key, so the state blob in B2 is encrypted at rest independent of B2's own encryption. The passphrase is itself a seeded root secret (§7) — it can **not** live in Infisical (state may contain the Infisical bootstrap creds). Store it in GitHub Actions secrets (`TF_STATE_PASSPHRASE`) and your password manager.
+
+```hcl
+terraform {
+  encryption {
+    key_provider "pbkdf2" "k" { passphrase = var.state_passphrase }
+    method "aes_gcm" "m" { keys = key_provider.pbkdf2.k }
+    state  { method = method.aes_gcm.m }
+    plan   { method = method.aes_gcm.m }
+  }
+}
+```
+
+**Interaction with Infisical migration:** state will contain Infisical machine-identity secrets and B2 keys as resource attributes. Treat the state file as Tier-0 secret material — hence encryption + restricted bucket key + never committed. This is *why* secret **values** stay in Infisical and TF only manages structure (§5): minimizing secret material that lands in state.
+
+---
+
+## 4. Repo layout
+
+Single cluster, single environment → **directory-per-domain, NOT per-environment, NOT workspaces.** Multi-env abstraction (`dev`/`prod` workspaces) is premature complexity for one cluster; adding it now buys nothing and taxes every change. Use a flat `terraform/` tree with one module per external domain.
+
+```
+terraform/
+├── README.md                  # bootstrap order, seeded creds, how to run
+├── versions.tf                # required_version, provider pins
+├── backend.tf                 # B2 s3 backend + encryption block
+├── providers.tf               # provider configs (creds from env/Infisical)
+├── main.tf                    # module wiring
+├── variables.tf
+├── outputs.tf                 # bucket names, identity IDs (non-secret)
+└── modules/
+    ├── b2/                    # buckets + scoped app keys
+    ├── dns/                   # *.jarrodservilla.com records
+    ├── tailscale/             # ACL doc + CI auth key + tags
+    ├── authentik/             # OAuth apps/providers/groups
+    ├── infisical-platform/    # projects, folders, machine identities, policies (STRUCTURE only)
+    └── cluster-bootstrap/     # node labels only
+```
+
+Keep it one root module + child modules (no remote module registry, no Terragrunt — overkill for one operator). Phase gating (§8) is done by commenting module blocks in `main.tf`, not by separate roots.
+
+---
+
+## 5. Secrets flow — two distinct layers
+
+**Layer (a): TF *manages* the Infisical platform.** The `infisical-platform` module creates `infisical_project`, folder structure, `infisical_identity` (machine identities for the operator + each consumer), and access policies. It defines **structure and access**, and writes **zero secret values**. The actual secret material (B2 keys, DB passwords, OAuth client secrets) is typed into Infisical by hand or written by the *resource that generates it* — e.g. a B2 app key created by TF is written into Infisical via `infisical_secret` **only if** you accept it landing in state; preferred alternative: TF outputs the key once to the operator, who pastes it into Infisical, keeping it out of long-lived state.
+
+**Layer (b): TF *consumes* secrets from Infisical at plan/apply.** Provider credentials (Authentik API token, Tailscale OAuth, DNS API token) are read from Infisical via the `infisical` provider's data sources, or injected as env vars by the Infisical CLI wrapping `tofu` (`infisical run -- tofu apply`). The latter is simpler and matches your existing `infisical scan` CI usage.
+
+**The bootstrap loop:** TF needs an Infisical machine identity to read the creds it needs — but that identity can't live inside the Infisical it's managing. **Resolution:** one manually-created, long-lived **Infisical "bootstrap" machine identity** (Universal Auth client-id/secret), seeded by hand in the Infisical UI, stored in GitHub Actions secrets (`INFISICAL_CLIENT_ID` / `INFISICAL_CLIENT_SECRET`) and your password manager — never in Infisical, never in state. Everything else (consumer identities, scoped tokens) is then TF-managed. **Avoiding a second source of truth:** secret *values* live only in Infisical; TF owns the *containers and access rules*. No plaintext is ever committed; the only secrets outside Infisical are the irreducible bootstrap roots in §7.
+
+---
+
+## 6. CI/CD integration
+
+Add a sibling workflow `.github/workflows/terraform.yml` — **do not** entangle it with `ci.yml`'s Helm job. Mirror the existing patterns (Tailscale OAuth action, Infisical CLI, path filters).
+
+- **Trigger:** `pull_request` + `push: main`, both `paths: ['terraform/**']` so Helm-only changes don't run TF and vice-versa.
+- **Plan on PR:** `tofu plan` against a `terraform/**` diff, post plan as PR comment. No cluster mutation. Read-only providers (B2/DNS/Authentik/Tailscale) plan fine; the Infisical/k8s providers need API reachability.
+- **Apply on merge:** `push: main` runs `tofu apply` with a `concurrency: { group: terraform, cancel-in-progress: false }` guard (the locking substitute from §3).
+- **Manual-approval gate:** wrap `apply` in a GitHub **Environment** (`terraform-prod`) with required reviewer = you. One-click approval, full audit trail.
+- **Drift detection:** scheduled `tofu plan` (weekly cron) that opens/updates an issue if drift is found. Low effort, high value for click-ops resources that get hand-edited.
+- **When apply needs cluster access:** only the `cluster-bootstrap` (node labels) and `infisical-platform` modules talk to the cluster. Reuse the **exact existing path** — `tailscale/github-action@v4` + base64 `KUBE_CONFIG` secret → `~/.kube/config`. No new connectivity mechanism.
+- **Secrets into TF:** `infisical run --env=prod -- tofu apply`, with the bootstrap identity from GH secrets. Mirrors how `infisical scan` already runs in `ci.yml`.
+
+---
+
+## 7. Bootstrap & dependency ordering
+
+The chicken-and-egg knot has **four** seeded roots. These are the *only* manually-created credentials; everything downstream is TF-managed.
+
+**Manually seeded (Tier-0, live in password manager + GitHub Actions secrets, never in state, never in Infisical):**
+
+1. **B2 master/management app key** — needed to create the state bucket *and* to let the b2 provider create other buckets. Create the `homelab-tofu-state` bucket **by hand** (it can't be TF-managed; it stores the state that would manage it).
+2. **OpenTofu state passphrase** (`TF_STATE_PASSPHRASE`) — encrypts state; can't live in Infisical because state holds Infisical creds.
+3. **Infisical bootstrap machine identity** (`INFISICAL_CLIENT_ID/SECRET`) — lets TF manage Infisical; can't live in the Infisical it manages.
+4. **Cluster kubeconfig** (`KUBE_CONFIG`, already exists) + **Tailscale OAuth** (already exists) — for the minimal cluster-touching modules.
+
+**Bootstrap sequence (one-time, manual then automated):**
+
+```
+0. (manual) Create B2 mgmt key + `homelab-tofu-state` bucket.
+1. (manual) Create Infisical bootstrap machine identity in UI.
+2. (manual) Seed the 4 Tier-0 secrets into GitHub Actions secrets + password manager.
+3. tofu init  (backend points at the hand-made state bucket, encryption on)
+4. tofu apply -target=module.infisical-platform   # creates projects/folders/identities
+5. (manual) Paste real secret VALUES into the newly-created Infisical folders.
+6. tofu apply  # b2 (other buckets/keys), dns, tailscale, authentik, cluster-bootstrap
+7. (import existing live resources — see §8)
+```
+
+**Self-hosted Infisical caveat:** because Infisical runs *in the cluster* (`charts/infisical`), the platform that holds your secrets depends on the cluster being up, and TF managing Infisical depends on Infisical being up. This is fine in steady state but means **full DR cannot bootstrap from Infisical** — the 4 Tier-0 roots in your password manager are the true recovery root. Document this in `terraform/README.md` as the disaster-recovery entry point.
+
+---
+
+## 8. Migration path
+
+**Phase 1 (do this first): B2 + DNS via `import`.** Lowest risk (read-mostly, no cluster dependency, no Infisical dependency for the providers if you seed their keys directly), highest DR payoff (these are the resources you most need and least have documented). Both import cleanly.
+
+- **Phase 2:** Tailscale ACL + CI auth key (security value, ACL already JSON).
+- **Phase 3:** Infisical platform structure (unlocks §5 properly).
+- **Phase 4:** Authentik OAuth apps/groups.
+- **Phase 5 (optional):** cluster node labels.
+
+**Import, never recreate.** Every resource here is live and stateful — recreating a B2 bucket orphans backups; recreating DNS causes resolution outages; recreating an Authentik provider breaks Grafana SSO. Use `import` blocks (OpenTofu 1.6+ declarative imports) so the import itself is reviewable in a PR plan:
+
+```hcl
+import {
+  to = module.b2.b2_bucket.restic
+  id = "<bucket-id>"
+}
+```
+
+**Orphaning risk & mitigation:** the danger is a `plan` that shows *destroy+recreate* instead of *no-op* after import (usually from an attribute the provider computes differently). **Rule: never approve a Phase-1 apply that shows any `destroy` on a B2 bucket or DNS record.** Import, run plan, confirm it's a clean no-op or in-place update only, *then* merge. For backups specifically, B2 bucket lifecycle/retention attributes are the usual culprit — set them in HCL to match reality *before* the first apply.
+
+---
+
+## 9. Risks & anti-patterns
+
+- **Forking the deployment model.** The biggest risk is scope creep into Helm/workloads. If a future change tempts you toward `helm_release`, stop — that's the line this whole doc exists to hold.
+- **Single-operator maintenance tax.** Provider upgrades (esp. Infisical and Authentik, which track server versions) will break plans. Pin everything; budget for occasional breakage. If you're not running `tofu` monthly, drift detection + the seeded roots matter more than coverage.
+- **State-as-liability.** State now contains secret material. A leaked state file ≈ leaked B2 keys + Infisical creds. Encryption + restricted bucket key are mandatory, not optional.
+- **Locking false-confidence.** B2 backend locking is weak; the CI concurrency group is the real guard. Don't run local `apply` while CI might.
+- **When NOT to use TF here:** anything Helm already does well; anything expressible in `values/network.yaml`; one-off resources you'll never change; secret *values* (Infisical's job). If a domain has <3 resources and never changes, importing it may cost more than it saves — node labels are borderline; do them only if Phase 1–4 prove the workflow.
+- **Premature multi-env.** Resisted in §4 — re-flag here so it doesn't creep back.
+
+---
+
+## First-PR task list (one sitting)
+
+Scope: **stand up the skeleton + Phase 1 B2 import, plan-only.** No apply of new resources yet.
+
+1. **Decide & confirm assumptions:** DNS registrar (Cloudflare?), B2 region, Tailscale tier, Authentik version, Infisical self-hosted confirmation. Block on these for provider pins.
+2. **Manually seed Tier-0:** create B2 mgmt key + `homelab-tofu-state` bucket; generate `TF_STATE_PASSPHRASE`; create Infisical bootstrap identity. Store all in password manager + GitHub Actions secrets.
+3. **Create `terraform/` skeleton:** `versions.tf` (pin OpenTofu + providers), `backend.tf` (B2 s3 + native encryption), `providers.tf`, empty `main.tf`/`variables.tf`/`outputs.tf`, and `README.md` documenting the §7 bootstrap + DR roots.
+4. **Add `modules/b2/`:** `b2_bucket` + scoped `b2_application_key` resources for the 4 backup buckets, attributes matching current reality (lifecycle/retention).
+5. **Add `import` blocks** for the existing B2 buckets; run `tofu plan`; confirm **clean no-op** (zero destroys).
+6. **Add `.github/workflows/terraform.yml`:** `paths: ['terraform/**']`, plan-on-PR (comment), apply-on-merge behind a `terraform-prod` GitHub Environment + `concurrency: terraform`. Reuse Tailscale OAuth + Infisical CLI patterns from `ci.yml`.
+7. **Update `.gitignore`** for `*.tfstate*`, `.terraform/`, `*.tfplan`; add `terraform/` note to `CLAUDE.md` so the deployment-model boundary (TF=gap, Helm=workloads) is documented for future sessions.

--- a/docs/terraform-implementation-prompt.md
+++ b/docs/terraform-implementation-prompt.md
@@ -1,0 +1,44 @@
+# Implementation Prompt: Bootstrap OpenTofu for homelab-k8s External-Resource Gap
+
+## Role
+You are a senior DevOps/platform engineer with deep OpenTofu/Terraform, GitOps, and GitHub Actions experience. You implement incrementally, import live infrastructure without orphaning it, and never break a working pipeline. You write reviewable PRs and stop at risk boundaries to confirm with the operator.
+
+## Source of truth
+Read `docs/terraform-architecture-scoping.md` in this repo first — it is the approved architecture. Do not re-litigate its decisions (OpenTofu over Terraform; manage the external "gap" only; no `helm` provider; minimal `kubernetes`; B2 s3 backend with native state encryption; directory-per-domain not multi-env; four Tier-0 seeded roots; Phase 1 = B2 + DNS via import). Implement against it. If you find a decision is wrong in light of live state, raise it as a blocking question — do not silently deviate.
+
+## Context: the existing system (do not change)
+4-node HA K3s cluster on Raspberry Pi. All workloads are Helm charts under `charts/`. `.github/workflows/ci.yml` runs: `infisical scan` → `ct lint` (kind) → `deploy` (main-only) which connects via `tailscale/github-action@v4` + base64 `KUBE_CONFIG` secret and runs `helm upgrade --install` on charts changed in `git diff HEAD~1 HEAD`. Secrets are mid-migration from kubeseal SealedSecrets to **self-hosted, in-cluster Infisical** (`charts/infisical`, operator-based). `values/network.yaml` is the single source of truth for IP/network config. **The Helm pipeline must keep working unchanged.**
+
+## Scope of THIS implementation (Phase 0 + Phase 1, plan-only)
+Deliver the OpenTofu skeleton and the **B2 backup-bucket import**, ending at a **clean `tofu plan` no-op** — no apply of new resources, no `destroy` on any live resource. DNS (rest of Phase 1) and later phases are out of scope for this PR unless explicitly requested.
+
+In scope:
+1. `terraform/` skeleton: `versions.tf` (pin OpenTofu + each provider), `backend.tf` (B2 S3-compatible backend + OpenTofu native PBKDF2/AES-GCM state encryption), `providers.tf`, `main.tf`, `variables.tf`, `outputs.tf`, `README.md` (bootstrap order + DR roots from §7 of the spec).
+2. `modules/b2/`: `b2_bucket` + per-bucket scoped `b2_application_key` for the 4 backup buckets (restic, immich-db, home-assistant, open-archiver), with lifecycle/retention attributes matching live reality.
+3. `import` blocks (OpenTofu 1.6+ declarative) for the existing B2 buckets.
+4. `.github/workflows/terraform.yml`: `paths: ['terraform/**']`, plan-on-PR (post plan as comment), apply-on-merge behind a `terraform-prod` GitHub Environment + `concurrency: { group: terraform, cancel-in-progress: false }`. Reuse the existing Tailscale OAuth + Infisical CLI patterns from `ci.yml` verbatim where possible.
+5. `.gitignore` entries: `*.tfstate*`, `.terraform/`, `*.tfplan`, `*.tfvars` (except committed examples). Add a `terraform/` note to `CLAUDE.md` documenting the boundary: **TF = external gap, Helm = workloads.**
+
+Explicitly OUT of scope: any `helm_release`; any `kubernetes` resource beyond what the spec allows (node labels are Phase 5, not now); DNS/Tailscale/Authentik/Infisical-platform modules; any `tofu apply` that creates or destroys real resources.
+
+## Blocking inputs — confirm before writing provider pins
+Stop and ask the operator for these; do not guess:
+- B2 region + S3 endpoint host (e.g. `us-west-004` / `s3.us-west-004.backblazeb2.com`).
+- Exact live B2 bucket names + bucket IDs for the 4 backups (needed for `import` blocks).
+- Whether the 4 Tier-0 roots are already seeded (B2 mgmt key, `homelab-tofu-state` bucket, `TF_STATE_PASSPHRASE`, Infisical bootstrap identity). If not, provide the exact manual steps and pause.
+- DNS registrar (spec assumes Cloudflare) — only needed if you also touch DNS; otherwise note as deferred.
+
+## Hard constraints
+- Providers run on the **amd64 GitHub runner / operator laptop**, never on the Pis. No ARM64 build concern.
+- Secret VALUES never enter code or state where avoidable; provider creds come from GitHub Actions secrets / `infisical run -- tofu ...`. No plaintext committed. The state passphrase and Infisical bootstrap identity must NOT live in Infisical (state contains Infisical creds).
+- The B2 state bucket is created BY HAND and is NOT TF-managed (it stores the state that would manage it).
+- Locking: B2 backend locking is weak — rely on the CI `concurrency` group. Never run a local `apply` that could race CI.
+
+## Definition of done
+- `tofu init` succeeds against the hand-created encrypted B2 state bucket.
+- `tofu plan` on the B2 module after import shows a **clean no-op or in-place-only** result — zero `destroy`, zero `create` on live buckets. Paste the plan output in the PR.
+- `terraform.yml` runs plan on PR and is gated for apply-on-merge; it does NOT trigger on Helm-only changes, and `ci.yml` does NOT trigger on `terraform/**` changes.
+- A reviewer can read `terraform/README.md` and reproduce the bootstrap + understand the DR root credentials.
+
+## Working style
+Follow the repo conventions (yamllint/yamlfix, selective per-file staging, no `git add -A`). Branch off `main`; do not commit or push unless asked. Start writing files within the first few tool calls — cap exploration; the spec already did the discovery. If a `plan` shows any destroy on a live bucket, STOP and surface it — that is the orphaning risk the spec calls out, and it is never auto-resolved. Produce a single focused PR matching the "First-PR task list" in the spec.

--- a/docs/terraform-scoping-prompt.md
+++ b/docs/terraform-scoping-prompt.md
@@ -1,0 +1,42 @@
+# Prompt: Scope Terraform Architecture for Homelab K3s GitOps Repo
+
+## Role
+You are a senior DevOps/platform architect specializing in Infrastructure-as-Code, GitOps, and hybrid Kubernetes + cloud-resource management. You design pragmatic, incremental adoption paths — not greenfield rewrites.
+
+## Context: the existing system
+A 4-node HA K3s cluster on Raspberry Pi hardware (2× Pi4 4GB, 2× Pi5 8GB) running self-hosted services. Current state:
+
+- **Deployment model:** GitOps-style. All workloads are Helm charts under `charts/`. Pushes to `main` trigger GitHub Actions CI (`.github/workflows/ci.yml`) that lints changed charts (`ct lint`) and runs `helm upgrade --install --wait --atomic`, connecting to the cluster over Tailscale. Namespace derived from each chart's `values.yaml`.
+- **Charts in play:** infra (metallb, cert-manager, nginx-ingress, sealed-secrets, network-policies), monitoring (kube-prometheus-stack, loki, alloy, blackbox-exporter), apps (immich, home-assistant, pihole, authentik, librechat, open-archiver, recipe-rip, nas-services), backups (restic, immich-db, home-assistant, authentik CronJobs).
+- **Secrets:** migrating from kubeseal SealedSecrets → Infisical (operator-based). `.env` holds raw creds, never committed.
+- **External dependencies NOT currently managed as code:**
+  - Backblaze B2 — buckets + app keys for restic/immich-db/HA/open-archiver backups
+  - DNS — records for `*.jarrodservilla.com`
+  - Tailscale — ACLs, device tags, auth keys (CI auth path)
+  - Authentik — OAuth apps/providers/groups (Grafana, others)
+  - Infisical — projects, folder structure, env scopes, machine identities / service tokens, and access policies for the secret-management platform itself (currently configured by hand in the Infisical UI; the operator consumes it but doesn't define it)
+  - Cluster bootstrap concerns — node labels (`zigbee=true` on pi4-02, `storage=true` on pi5-01), node affinity constraints
+- **Constraints:** single operator (hobbyist-but-rigorous), ARM64 hardware, limited RAM/compute, must not break the working Helm CI pipeline, prefers simplest solution that works, GitOps reviewability is a core value.
+
+## Your task
+Produce an **architecture scoping document** for introducing Terraform (or OpenTofu — recommend and justify a choice) into this repo. The explicit design goal is to manage the **gap** — external/cloud resources and bootstrap concerns currently handled manually — NOT to replace the working Helm deployment pipeline. Challenge that goal if you believe it's wrong, with reasoning.
+
+## Deliverable structure
+Address each, concretely:
+
+1. **Scope boundary** — Draw the precise line between what Terraform should own vs. what stays in Helm/CI. Justify. Call out any resources where ownership is genuinely ambiguous (e.g. should TF manage Helm releases via the helm provider, or stay out?).
+2. **Provider selection** — Which providers (b2, cloudflare/dns, tailscale, authentik, infisical, kubernetes, helm, etc.), maturity/maintenance risk of each, and ARM64/runner implications.
+3. **State management** — Backend choice. Evaluate B2 (S3-compatible, already paid for) as remote state backend incl. locking limitations. Address state encryption given secrets adjacency, and how state interacts with the Infisical migration.
+4. **Repo layout** — Directory structure, module boundaries, workspace vs. directory-per-environment (note: single cluster, so weigh whether multi-env abstraction is premature). Show a concrete tree.
+5. **Secrets flow** — Distinguish two layers: (a) Terraform *managing the Infisical platform* (folders, identities, policies) via the infisical provider, vs. (b) Terraform *consuming* secrets from Infisical at plan/apply time. Address the bootstrap loop — TF needs an Infisical identity to manage Infisical, and that identity can't itself live in the thing it's bootstrapping. Avoid a second source of truth: secret *values* stay in Infisical; TF owns *structure/access*, not the secret material. No plaintext committed.
+6. **CI/CD integration** — How `terraform plan`/`apply` fits alongside the existing Helm CI job. Plan-on-PR, apply-on-merge, drift detection, manual-approval gates. Keep it consistent with current GitHub Actions + Tailscale patterns. Address: what happens when an apply needs cluster access.
+7. **Bootstrap & dependency ordering** — Chicken-and-egg problems: TF needs cluster access, state needs B2, B2 keys might be TF-managed, and the Infisical identity that lets TF manage Infisical is itself a manually-seeded root credential — document where it lives. Define the full bootstrap sequence and what's manually seeded.
+8. **Migration path** — Phased rollout. Phase 1 should be the lowest-risk, highest-value slice (your pick — justify). For existing manually-created resources, `import` strategy vs. recreate. Risk of orphaning live backups/DNS during import.
+9. **Risks & anti-patterns** — Where this could add complexity without payoff. When to NOT use Terraform here. Single-operator maintenance burden.
+
+## Output requirements
+- Lead with a 5-sentence executive summary + an explicit **go / partial-go / don't-bother** recommendation.
+- Be opinionated and decisive; give one recommended path, note alternatives in one line each — no exhaustive option-surveys.
+- Concrete over abstract: real provider names, real resource types, real file paths matching this repo's conventions.
+- Flag every assumption you make about unstated details (B2 region, DNS registrar, Tailscale tier, Authentik version, Infisical self-hosted vs. cloud).
+- End with a prioritized, numbered first-PR task list small enough to land in one sitting.

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -78,37 +78,41 @@ locally** while CI might — one human + one runner = no contention if you don't
 
 ## Phase 2: Tailscale
 
-Brings the tailnet under TF: **ACL-as-code**, **TF-managed device tags** on cluster
-nodes, and a **TF-managed tailnet auth key**. Module: `modules/tailscale/`.
+Brings the tailnet under TF: **ACL-as-code** and a **TF-managed tailnet auth key**.
+Module: `modules/tailscale/`.
 
-**Not fully plan-only.** The ACL and every `tailscale_device_tags` are
-import->no-op (mirror the B2 discipline). The **one apply** is
-`tailscale_tailnet_key.ci` — a key's `key` secret is never returned on import, so it
-is inherently a CREATE.
+**Not fully plan-only.** The ACL is import->no-op (mirror the B2 discipline). The
+**one apply** is `tailscale_tailnet_key.ci` — a key's `key` secret is never returned
+on import, so it is inherently a CREATE.
+
+**Device tags deferred.** The cluster nodes (`pi4-01/02`, `pi5-01/02`) are
+**user-owned (untagged) live**, so TF-managing their tags would be a real
+ownership-changing mutation, not an import-no-op — it would subject them to ACL tag
+rules and risk cluster connectivity. Tagging is left to a deliberate follow-up: add
+the node tag to `tagOwners` + the necessary `grants` in `acl.hujson`, then apply.
 
 ### New OAuth client + GH secrets (Tier-0-adjacent, hand-made)
 
 The Tailscale **provider** authenticates with a **new** OAuth client, distinct from
 the node-auth `TS_OAUTH_*` (which the `tailscale/github-action` uses to self-mint
-ephemeral node keys). Create it in the admin console with scopes:
+ephemeral node keys). Create it in the admin console with scopes (new UI names):
 
-- `acl` (write) — manage the policy file
-- `auth_keys` — create the tailnet key
-- `devices:core` (write) — set device tags
+- **General → Policy File** (read + write) — manage the ACL
+- **Keys → Auth Keys** (read + write) — create the tailnet key
+- **Devices → Core** (read + write) — reserved for the deferred device-tag follow-up
 
-It must **own every tag it manages** (`tag:github-actions` + the node tags). Seed its
-id/secret into GH Actions secrets `TS_TF_OAUTH_CLIENT_ID` / `TS_TF_OAUTH_CLIENT_SECRET`
-(+ password manager). The provider reads env `TAILSCALE_OAUTH_CLIENT_ID` /
-`TAILSCALE_OAUTH_CLIENT_SECRET`. It hits the public `api.tailscale.com` — **no cluster
-VPN**, so `terraform.yml`'s commented `Connect to Tailscale` step stays commented.
+It must **own every tag it manages** (currently `tag:github-actions`; add node tags
+when tagging lands). Seed its id/secret into GH Actions secrets
+`TS_TF_OAUTH_CLIENT_ID` / `TS_TF_OAUTH_CLIENT_SECRET` (+ password manager). The
+provider reads env `TAILSCALE_OAUTH_CLIENT_ID` / `TAILSCALE_OAUTH_CLIENT_SECRET`. It
+hits the public `api.tailscale.com` — **no cluster VPN**, so `terraform.yml`'s
+commented `Connect to Tailscale` step stays commented.
 
 ### Required inputs before plan
 
 - `modules/tailscale/acl.hujson` — the live ACL, exported verbatim (HuJSON
   formatting/comments are the drift culprit). Must declare `tagOwners` for every tag
   used or the provider rejects it.
-- `var.managed_nodes` (in `modules/tailscale/variables.tf`) — node hostname + tag set.
-- Device-tag `import` blocks in `main.tf` — one per node, `id = "<nodeID>CNTRL"`.
 
 ### Running (adds to the env in "Running" above)
 
@@ -116,7 +120,7 @@ VPN**, so `terraform.yml`'s commented `Connect to Tailscale` step stays commente
 export TAILSCALE_OAUTH_CLIENT_ID=...      # new ACL-scoped OAuth client
 export TAILSCALE_OAUTH_CLIENT_SECRET=...
 tofu init
-tofu plan   # ACL + all device_tags = no-op; tailscale_tailnet_key.ci = the only create
+tofu plan   # ACL = no-op; tailscale_tailnet_key.ci = the only create
 ```
 
 After apply, read the key once: `tofu output -raw ci_auth_key` (Infisical storage

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -76,6 +76,53 @@ B2's S3 API has no DynamoDB-style locking. **Mitigation: serialize applies throu
 (`concurrency: { group: terraform, cancel-in-progress: false }`). **Never run `tofu apply`
 locally** while CI might — one human + one runner = no contention if you don't race them.
 
+## Phase 2: Tailscale
+
+Brings the tailnet under TF: **ACL-as-code**, **TF-managed device tags** on cluster
+nodes, and a **TF-managed tailnet auth key**. Module: `modules/tailscale/`.
+
+**Not fully plan-only.** The ACL and every `tailscale_device_tags` are
+import->no-op (mirror the B2 discipline). The **one apply** is
+`tailscale_tailnet_key.ci` — a key's `key` secret is never returned on import, so it
+is inherently a CREATE.
+
+### New OAuth client + GH secrets (Tier-0-adjacent, hand-made)
+
+The Tailscale **provider** authenticates with a **new** OAuth client, distinct from
+the node-auth `TS_OAUTH_*` (which the `tailscale/github-action` uses to self-mint
+ephemeral node keys). Create it in the admin console with scopes:
+
+- `acl` (write) — manage the policy file
+- `auth_keys` — create the tailnet key
+- `devices:core` (write) — set device tags
+
+It must **own every tag it manages** (`tag:github-actions` + the node tags). Seed its
+id/secret into GH Actions secrets `TS_TF_OAUTH_CLIENT_ID` / `TS_TF_OAUTH_CLIENT_SECRET`
+(+ password manager). The provider reads env `TAILSCALE_OAUTH_CLIENT_ID` /
+`TAILSCALE_OAUTH_CLIENT_SECRET`. It hits the public `api.tailscale.com` — **no cluster
+VPN**, so `terraform.yml`'s commented `Connect to Tailscale` step stays commented.
+
+### Required inputs before plan
+
+- `modules/tailscale/acl.hujson` — the live ACL, exported verbatim (HuJSON
+  formatting/comments are the drift culprit). Must declare `tagOwners` for every tag
+  used or the provider rejects it.
+- `var.managed_nodes` (in `modules/tailscale/variables.tf`) — node hostname + tag set.
+- Device-tag `import` blocks in `main.tf` — one per node, `id = "<nodeID>CNTRL"`.
+
+### Running (adds to the env in "Running" above)
+
+```bash
+export TAILSCALE_OAUTH_CLIENT_ID=...      # new ACL-scoped OAuth client
+export TAILSCALE_OAUTH_CLIENT_SECRET=...
+tofu init
+tofu plan   # ACL + all device_tags = no-op; tailscale_tailnet_key.ci = the only create
+```
+
+After apply, read the key once: `tofu output -raw ci_auth_key` (Infisical storage
+deferred to Phase 3). The key is for manual/other node joins (NAS, re-imaging a Pi);
+CI does not consume it.
+
 ## HARD STOP rule (import safety)
 
 After import, if `tofu plan` shows ANY `destroy`/replace on a live bucket, **do not apply** —

--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -9,8 +9,6 @@ terraform {
     endpoints = {
       s3 = "https://s3.ca-east-006.backblazeb2.com"
     }
-
-    # B2's S3 API is not AWS — skip AWS-specific validation/metadata calls.
     skip_credentials_validation = true
     skip_region_validation      = true
     skip_requesting_account_id  = true
@@ -18,8 +16,6 @@ terraform {
     use_path_style              = true
   }
 
-  # OpenTofu native state encryption (PBKDF2/AES-GCM). Passphrase is a Tier-0 root
-  # (TF_VAR_state_passphrase) — never in Infisical, since state holds Infisical creds.
   encryption {
     key_provider "pbkdf2" "k" {
       passphrase = var.state_passphrase

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -40,25 +40,19 @@ import {
 }
 
 # ---------------------------------------------------------------------------
-# Phase 2 — Tailscale. Import the live ACL + each managed node's device tags into
-# state WITHOUT mutating them. tailscale_tailnet_key.ci is intentionally NOT
-# imported — it's the lone CREATE (its `key` secret is never returned on import).
+# Phase 2 — Tailscale. Import the live ACL into state WITHOUT mutating it.
+# tailscale_tailnet_key.ci is intentionally NOT imported — it's the lone CREATE
+# (its `key` secret is never returned on import).
 #
-# HARD STOP: if `tofu plan` shows ANY destroy/replace on the ACL or a node's tags,
-# do not apply. Reconcile acl.hujson / managed_nodes to live first. A bad ACL push
-# can lock the tailnet — treat it like a backup bucket.
+# Device tags are NOT managed: cluster nodes are user-owned (untagged) live, so
+# tagging is a real mutation, not an import. Deferred to a follow-up.
+#
+# HARD STOP: if `tofu plan` shows ANY destroy/replace on the ACL, do not apply.
+# Reconcile acl.hujson to live first. A bad ACL push can lock the tailnet — treat
+# it like a backup bucket.
 # ---------------------------------------------------------------------------
 
 import {
   to = module.tailscale.tailscale_acl.this
   id = "acl"
 }
-
-# TODO(user data): one block per managed node. id = the node ID with the CNTRL
-# suffix (preferred), e.g. "nXXXXXXCNTRL", from `tailscale device list` / admin
-# console. The for_each key must match the managed_nodes map key in the module.
-#
-# import {
-#   to = module.tailscale.tailscale_device_tags.node["pi4_01"]
-#   id = "<nodeID>CNTRL"
-# }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -4,7 +4,10 @@ module "b2" {
   source = "./modules/b2"
 }
 
-# Phase 2: module "tailscale"        { source = "./modules/tailscale" }
+module "tailscale" {
+  source = "./modules/tailscale"
+}
+
 # Phase 3: module "infisical_platform" { source = "./modules/infisical-platform" }
 # Phase 4: module "authentik"        { source = "./modules/authentik" }
 # Phase 5: module "cluster_bootstrap" { source = "./modules/cluster-bootstrap" }
@@ -35,3 +38,27 @@ import {
   to = module.b2.b2_bucket.restic
   id = "5ad4be49abae28a291a2011d" # homelab-k3s-567f18
 }
+
+# ---------------------------------------------------------------------------
+# Phase 2 — Tailscale. Import the live ACL + each managed node's device tags into
+# state WITHOUT mutating them. tailscale_tailnet_key.ci is intentionally NOT
+# imported — it's the lone CREATE (its `key` secret is never returned on import).
+#
+# HARD STOP: if `tofu plan` shows ANY destroy/replace on the ACL or a node's tags,
+# do not apply. Reconcile acl.hujson / managed_nodes to live first. A bad ACL push
+# can lock the tailnet — treat it like a backup bucket.
+# ---------------------------------------------------------------------------
+
+import {
+  to = module.tailscale.tailscale_acl.this
+  id = "acl"
+}
+
+# TODO(user data): one block per managed node. id = the node ID with the CNTRL
+# suffix (preferred), e.g. "nXXXXXXCNTRL", from `tailscale device list` / admin
+# console. The for_each key must match the managed_nodes map key in the module.
+#
+# import {
+#   to = module.tailscale.tailscale_device_tags.node["pi4_01"]
+#   id = "<nodeID>CNTRL"
+# }

--- a/terraform/modules/b2/main.tf
+++ b/terraform/modules/b2/main.tf
@@ -7,15 +7,11 @@
 #   restic            ->  homelab-k3s-567f18        ca-east-006   restic-backup
 #
 # All bucket_type allPrivate. Imported via `import` blocks in ../../main.tf.
-# IMPORTANT: if `tofu plan` post-import shows destroy/replace, the culprit is
-# almost always lifecycle_rules / bucket_info differing from live — set them
-# here to match what `b2 get-bucket <name>` reports, then re-plan.
 
 resource "b2_bucket" "homelab_backups" {
   bucket_name = "homelab-backups-431118"
   bucket_type = "allPrivate"
 
-  # Live bucket has SSE-B2 enabled — declare it to match, else plan disables it.
   default_server_side_encryption {
     mode      = "SSE-B2"
     algorithm = "AES256"
@@ -25,15 +21,11 @@ resource "b2_bucket" "homelab_backups" {
 resource "b2_bucket" "open_archiver" {
   bucket_name = "open-archiver-homelab"
   bucket_type = "allPrivate"
-
-  # lifecycle_rules / bucket_info: add to match live if plan is not a clean no-op.
 }
 
 resource "b2_bucket" "restic" {
   bucket_name = "homelab-k3s-567f18"
   bucket_type = "allPrivate"
-
-  # lifecycle_rules / bucket_info: add to match live if plan is not a clean no-op.
 }
 
 # ---------------------------------------------------------------------------

--- a/terraform/modules/tailscale/acl.hujson
+++ b/terraform/modules/tailscale/acl.hujson
@@ -1,0 +1,79 @@
+// Example/default ACLs for unrestricted connections.
+{
+	// Declare static groups of users. Use autogroups for all users or users with a specific role.
+	// "groups": {
+	//   "group:example": ["alice@example.com", "bob@example.com"],
+	// },
+
+	// Define the tags which can be applied to devices and by which users.
+	// "tagOwners": {
+	//   "tag:example": ["autogroup:admin"],
+	// },
+
+	// Define grants that govern access for users, groups, autogroups, tags,
+	// Tailscale IP addresses, and subnet ranges.
+	"grants": [
+		{
+			"src": ["tag:github-actions"],
+			"dst": ["*"],
+			"ip":  ["6443"],
+		},
+		// Allow exit nodes
+		{
+			"src": ["autogroup:member"],
+			"dst": ["autogroup:internet"],
+			"ip":  ["*"],
+		},
+
+		// Allow users in "group:example" to access "tag:example", but only from
+		// devices that are running macOS and have enabled Tailscale client auto-updating.
+		// {"src": ["group:example"], "dst": ["tag:example"], "ip": ["*"], "srcPosture":["posture:autoUpdateMac"]},
+	],
+
+	// Define postures that will be applied to all rules without any specific
+	// srcPosture definition.
+	// "defaultSrcPosture": [
+	//      "posture:anyMac",
+	// ],
+
+	// Define device posture rules requiring devices to meet
+	// certain criteria to access parts of your system.
+	// "postures": {
+	//      // Require devices running macOS, a stable Tailscale
+	//      // version and auto update enabled for Tailscale.
+	//  "posture:autoUpdateMac": [
+	//      "node:os == 'macos'",
+	//      "node:tsReleaseTrack == 'stable'",
+	//      "node:tsAutoUpdate",
+	//  ],
+	//      // Require devices running macOS and a stable
+	//      // Tailscale version.
+	//  "posture:anyMac": [
+	//      "node:os == 'macos'",
+	//      "node:tsReleaseTrack == 'stable'",
+	//  ],
+	// },
+
+	// Define users and devices that can use Tailscale SSH.
+	"ssh": [
+		// Allow all users to SSH into their own devices in check mode.
+		// Comment this section out if you want to define specific restrictions.
+		{
+			"action": "check",
+			"src":    ["autogroup:member"],
+			"dst":    ["autogroup:self"],
+			"users":  ["autogroup:nonroot", "root"],
+		},
+	],
+
+	"tagOwners": {"tag:github-actions": ["autogroup:admin"]},
+
+	// Test access rules every time they're saved.
+	// "tests": [
+	//   {
+	//       "src": "alice@example.com",
+	//       "accept": ["tag:example"],
+	//       "deny": ["100.101.102.103:443"],
+	//   },
+	// ],
+}

--- a/terraform/modules/tailscale/main.tf
+++ b/terraform/modules/tailscale/main.tf
@@ -1,0 +1,47 @@
+# Tailscale tailnet — ACL-as-code + TF-managed device tags + a tailnet auth key.
+#
+# Import discipline (mirrors B2): the ACL and every device_tags are import->no-op.
+# Only tailscale_tailnet_key.ci is a CREATE (its `key` secret is never returned on
+# import). HARD STOP: if `tofu plan` shows destroy/replace on the ACL or any tags,
+# fix HCL/acl.hujson to match live before applying — a bad ACL push can lock the
+# tailnet.
+
+# ---------------------------------------------------------------------------
+# ACL-as-code. Kept in acl.hujson so it's diffable as policy, not buried in HCL.
+# overwrite_existing_content/reset_acl_on_destroy left at defaults — the default
+# refusal-to-overwrite is the safety we want; import satisfies it.
+# ---------------------------------------------------------------------------
+resource "tailscale_acl" "this" {
+  acl = file("${path.module}/acl.hujson")
+}
+
+# ---------------------------------------------------------------------------
+# TF-managed device tags on the managed cluster nodes (import -> no-op).
+# Looks each device up by hostname, then owns its tag set.
+# ---------------------------------------------------------------------------
+data "tailscale_device" "node" {
+  for_each = var.managed_nodes
+  hostname = each.value.hostname
+  wait_for = "30s"
+}
+
+resource "tailscale_device_tags" "node" {
+  for_each  = var.managed_nodes
+  device_id = data.tailscale_device.node[each.key].node_id
+  tags      = each.value.tags
+}
+
+# ---------------------------------------------------------------------------
+# Tailnet auth key for manual/other node joins (NAS, re-imaging a Pi). CI's
+# github-action self-mints from TS_OAUTH_* and does NOT consume this. The lone
+# CREATE in this phase; `key` is sensitive -> surfaced via output, never committed.
+# Infisical storage of the value deferred to Phase 3.
+# ---------------------------------------------------------------------------
+resource "tailscale_tailnet_key" "ci" {
+  reusable      = true
+  ephemeral     = true
+  preauthorized = true
+  tags          = ["tag:github-actions"]
+  expiry        = var.ci_key_expiry_seconds
+  description   = "TF-managed node-join key (manual/NAS/re-image); see terraform/modules/tailscale"
+}

--- a/terraform/modules/tailscale/main.tf
+++ b/terraform/modules/tailscale/main.tf
@@ -1,10 +1,14 @@
-# Tailscale tailnet — ACL-as-code + TF-managed device tags + a tailnet auth key.
+# Tailscale tailnet — ACL-as-code + a tailnet auth key.
 #
-# Import discipline (mirrors B2): the ACL and every device_tags are import->no-op.
-# Only tailscale_tailnet_key.ci is a CREATE (its `key` secret is never returned on
-# import). HARD STOP: if `tofu plan` shows destroy/replace on the ACL or any tags,
-# fix HCL/acl.hujson to match live before applying — a bad ACL push can lock the
-# tailnet.
+# Import discipline (mirrors B2): the ACL is import->no-op. Only
+# tailscale_tailnet_key.ci is a CREATE (its `key` secret is never returned on
+# import). HARD STOP: if `tofu plan` shows destroy/replace on the ACL, fix
+# acl.hujson to match live before applying — a bad ACL push can lock the tailnet.
+#
+# Device tags are intentionally NOT managed here: the cluster nodes are currently
+# user-owned (untagged) live, so tagging them would be a real ownership-changing
+# mutation, not an import-no-op. Deferred to a deliberate follow-up (add the node
+# tag to tagOwners + grants in acl.hujson, then apply).
 
 # ---------------------------------------------------------------------------
 # ACL-as-code. Kept in acl.hujson so it's diffable as policy, not buried in HCL.
@@ -13,22 +17,6 @@
 # ---------------------------------------------------------------------------
 resource "tailscale_acl" "this" {
   acl = file("${path.module}/acl.hujson")
-}
-
-# ---------------------------------------------------------------------------
-# TF-managed device tags on the managed cluster nodes (import -> no-op).
-# Looks each device up by hostname, then owns its tag set.
-# ---------------------------------------------------------------------------
-data "tailscale_device" "node" {
-  for_each = var.managed_nodes
-  hostname = each.value.hostname
-  wait_for = "30s"
-}
-
-resource "tailscale_device_tags" "node" {
-  for_each  = var.managed_nodes
-  device_id = data.tailscale_device.node[each.key].node_id
-  tags      = each.value.tags
 }
 
 # ---------------------------------------------------------------------------
@@ -43,5 +31,5 @@ resource "tailscale_tailnet_key" "ci" {
   preauthorized = true
   tags          = ["tag:github-actions"]
   expiry        = var.ci_key_expiry_seconds
-  description   = "TF-managed node-join key (manual/NAS/re-image); see terraform/modules/tailscale"
+  description   = "TF node-join key (manual/NAS/re-image)"
 }

--- a/terraform/modules/tailscale/outputs.tf
+++ b/terraform/modules/tailscale/outputs.tf
@@ -5,9 +5,3 @@ output "ci_auth_key" {
   value       = tailscale_tailnet_key.ci.key
   sensitive   = true
 }
-
-# Non-secret: the node IDs whose tags TF owns (handy for the import blocks).
-output "tagged_device_ids" {
-  description = "Managed node logical name -> Tailscale node_id."
-  value       = { for k, d in data.tailscale_device.node : k => d.node_id }
-}

--- a/terraform/modules/tailscale/outputs.tf
+++ b/terraform/modules/tailscale/outputs.tf
@@ -1,0 +1,13 @@
+# Sensitive: the tailnet auth key value. Read with `tofu output -raw ci_auth_key`.
+# Never committed; Infisical storage deferred to Phase 3.
+output "ci_auth_key" {
+  description = "TF-managed tailnet auth key (sensitive)."
+  value       = tailscale_tailnet_key.ci.key
+  sensitive   = true
+}
+
+# Non-secret: the node IDs whose tags TF owns (handy for the import blocks).
+output "tagged_device_ids" {
+  description = "Managed node logical name -> Tailscale node_id."
+  value       = { for k, d in data.tailscale_device.node : k => d.node_id }
+}

--- a/terraform/modules/tailscale/variables.tf
+++ b/terraform/modules/tailscale/variables.tf
@@ -1,23 +1,3 @@
-# Managed cluster nodes -> Tailscale tags. Small + stable, so hardcoded here as a
-# map of { logical_name = { hostname, tags } }. `hostname` is the device's short
-# Tailscale hostname (looked up via the tailscale_device data source).
-#
-# TODO(user data): confirm hostnames + tag sets before plan. node IDs go in the
-# root import blocks, NOT here.
-variable "managed_nodes" {
-  description = "Cluster nodes whose Tailscale tags TF owns, keyed by logical name."
-  type = map(object({
-    hostname = string
-    tags     = list(string)
-  }))
-  default = {
-    # pi4_01 = { hostname = "pi4-01", tags = ["tag:k3s"] }
-    # pi4_02 = { hostname = "pi4-02", tags = ["tag:k3s"] }
-    # pi5_01 = { hostname = "pi5-01", tags = ["tag:k3s"] }
-    # pi5_02 = { hostname = "pi5-02", tags = ["tag:k3s"] }
-  }
-}
-
 # CI/manual node-join auth key. reusable+ephemeral+preauthorized by default.
 variable "ci_key_expiry_seconds" {
   description = "Expiry for the tailnet auth key, in seconds. Default 90 days."

--- a/terraform/modules/tailscale/variables.tf
+++ b/terraform/modules/tailscale/variables.tf
@@ -1,0 +1,26 @@
+# Managed cluster nodes -> Tailscale tags. Small + stable, so hardcoded here as a
+# map of { logical_name = { hostname, tags } }. `hostname` is the device's short
+# Tailscale hostname (looked up via the tailscale_device data source).
+#
+# TODO(user data): confirm hostnames + tag sets before plan. node IDs go in the
+# root import blocks, NOT here.
+variable "managed_nodes" {
+  description = "Cluster nodes whose Tailscale tags TF owns, keyed by logical name."
+  type = map(object({
+    hostname = string
+    tags     = list(string)
+  }))
+  default = {
+    # pi4_01 = { hostname = "pi4-01", tags = ["tag:k3s"] }
+    # pi4_02 = { hostname = "pi4-02", tags = ["tag:k3s"] }
+    # pi5_01 = { hostname = "pi5-01", tags = ["tag:k3s"] }
+    # pi5_02 = { hostname = "pi5-02", tags = ["tag:k3s"] }
+  }
+}
+
+# CI/manual node-join auth key. reusable+ephemeral+preauthorized by default.
+variable "ci_key_expiry_seconds" {
+  description = "Expiry for the tailnet auth key, in seconds. Default 90 days."
+  type        = number
+  default     = 7776000
+}

--- a/terraform/modules/tailscale/versions.tf
+++ b/terraform/modules/tailscale/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    tailscale = {
+      source  = "tailscale/tailscale"
+      version = "~> 0.29" # latest minor at impl time (0.29.2)
+    }
+  }
+}

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -1,2 +1,9 @@
 # Credentials from env: B2_APPLICATION_KEY_ID / B2_APPLICATION_KEY (the Tier-0 mgmt key).
 provider "b2" {}
+
+# Credentials from env: TAILSCALE_OAUTH_CLIENT_ID / TAILSCALE_OAUTH_CLIENT_SECRET
+# (the new ACL-scoped OAuth client, distinct from the node-auth TS_OAUTH_*).
+# tailnet "-" = the OAuth client's own default tailnet.
+provider "tailscale" {
+  tailnet = "-"
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,5 +1,4 @@
 terraform {
-  # >= 1.7.0: native state encryption GA'd in 1.7; declarative `import` blocks 1.6+.
   required_version = ">= 1.7.0"
 
   required_providers {
@@ -7,6 +6,9 @@ terraform {
       source  = "Backblaze/b2"
       version = "~> 0.12"
     }
-    # Other providers (dns, tailscale, authentik, infisical, kubernetes) added in later phases.
+    tailscale = {
+      source  = "tailscale/tailscale"
+      version = "~> 0.29"
+    }
   }
 }


### PR DESCRIPTION
# feat(terraform): Tailscale OpenTofu module (Phase 2)

## Summary

Brings the Tailscale tailnet under OpenTofu as the external "gap" Phase 2: **ACL-as-code**
(reviewable, recoverable) and a **TF-managed tailnet auth key**. The ACL is imported from the
live tailnet as a clean no-op; the auth key is the lone create (a key's secret is never returned
on import). Mirrors the B2 import-safety discipline — no destroy/replace anywhere.

**Scope change vs. the original plan:** device tags were dropped. The cluster nodes are
**user-owned (untagged) live**, so `tailscale_device_tags` would be a real ownership-changing
mutation, not an import-no-op. Tagging is deferred to a deliberate follow-up (add the node tag to
`tagOwners` + grants, then apply). This was confirmed against the live tailnet, not assumed.

## Verified plan

```
Plan: 1 to import, 1 to add, 0 to change, 0 to destroy.
```

- `tailscale_acl.this` — **import, 0 change** (acl.hujson is byte-identical to live; sha-matched)
- `tailscale_tailnet_key.ci` — **the only create** (reusable + ephemeral + preauthorized,
  `tag:github-actions`, 90d expiry; `key` surfaced via a sensitive output, never committed)

## Architecture

```mermaid
graph TD
    subgraph TF["OpenTofu (terraform/)"]
        ROOT["root: module wiring + ACL import block"]
        MOD["modules/tailscale"]
        ROOT --> MOD
        MOD --> ACL["tailscale_acl.this<br/>(import no-op)"]
        MOD --> KEY["tailscale_tailnet_key.ci<br/>(create)"]
        ACL -.reads.-> HUJSON["acl.hujson<br/>(verbatim live export)"]
    end
    PROV["provider tailscale<br/>(TAILSCALE_OAUTH_* env)"] --> API["api.tailscale.com"]
    MOD --> PROV
    KEY -.->|sensitive output| OUT["ci_auth_key<br/>(manual/NAS/re-image joins)"]
```

## What changed

**Tailscale module (`terraform/modules/tailscale/`)**
- `acl.hujson` — live ACL exported verbatim (HuJSON comments/formatting intact → import no-op)
- `main.tf` — `tailscale_acl.this` (reads `acl.hujson`) + `tailscale_tailnet_key.ci`
- `variables.tf` — `ci_key_expiry_seconds` (default 90d)
- `outputs.tf` — `ci_auth_key` (sensitive)
- `versions.tf` — pin `tailscale/tailscale ~> 0.29`

**Terraform root (`terraform/`)**
- `main.tf` — `module "tailscale"` wiring + declarative ACL `import` block (id `"acl"`); note that
  device tags are NOT managed and why
- `versions.tf` / `providers.tf` — add the `tailscale` provider (`tailnet = "-"`, OAuth via env)

**CI (`.github/workflows/terraform.yml`)**
- Top-level `env`: `TAILSCALE_OAUTH_CLIENT_ID/SECRET` ← new `TS_TF_OAUTH_*` GH secrets (the
  ACL-scoped OAuth client, distinct from the node-auth `TS_OAUTH_*`). Provider hits the public
  API, so the commented `Connect to Tailscale` step stays commented.

**Docs (`terraform/README.md`)**
- New "Phase 2: Tailscale" section: OAuth client + scopes, GH secrets, ACL import safety, the lone
  apply, and the device-tags deferral.

## Testing

- `tofu init` → installs `tailscale/tailscale v0.29.2`.
- `tofu plan` (against live, read-only) → `1 import, 1 add, 0 change, 0 destroy` (HARD STOP rule
  satisfied — zero destroy/replace on the ACL).
- On merge, `terraform.yml` applies behind the `terraform-prod` environment gate; the only create
  is the tailnet key. After apply: `tofu output -raw ci_auth_key`.

> Out of band, not in this diff: key expiry was disabled on the 3 nodes that still had it enabled
> (pi4-02/pi5-01/pi5-02) to stop them flapping off the tailnet — the permanent fix is the deferred
> node-tagging follow-up.

https://claude.ai/code/session_01FoBeKLNpyt2tUfwgwtHbvo
