### PR TITLE
feat(terraform): tag:k3s ACL grants + fix tailnet key description

### DIFF
--- a/terraform/modules/tailscale/acl.hujson
+++ b/terraform/modules/tailscale/acl.hujson
@@ -25,9 +25,20 @@
 			"ip":  ["*"],
 		},
 
-		// Allow users in "group:example" to access "tag:example", but only from
-		// devices that are running macOS and have enabled Tailscale client auto-updating.
-		// {"src": ["group:example"], "dst": ["tag:example"], "ip": ["*"], "srcPosture":["posture:autoUpdateMac"]},
+		// Admins (cluster operators) reach the k3s nodes on all ports — kubectl
+		// (6443), SSH, etc. Replaces the implicit access tagged nodes lose when
+		// they leave autogroup:member.
+		{
+			"src": ["autogroup:admin"],
+			"dst": ["tag:k3s"],
+			"ip":  ["*"],
+		},
+		// Admins reach the home LAN via pi4-01's advertised subnet route.
+		{
+			"src": ["autogroup:admin"],
+			"dst": ["10.2.1.0/24"],
+			"ip":  ["*"],
+		},
 	],
 
 	// Define postures that will be applied to all rules without any specific
@@ -64,16 +75,28 @@
 			"dst":    ["autogroup:self"],
 			"users":  ["autogroup:nonroot", "root"],
 		},
+		// Admins can Tailscale-SSH into the tagged k3s nodes (autogroup:self no
+		// longer covers them once they are tag-owned, not user-owned).
+		{
+			"action": "check",
+			"src":    ["autogroup:admin"],
+			"dst":    ["tag:k3s"],
+			"users":  ["autogroup:nonroot", "root"],
+		},
 	],
 
-	"tagOwners": {"tag:github-actions": ["autogroup:admin"]},
+	"tagOwners": {"tag:github-actions": ["autogroup:admin"], "tag:k3s": ["autogroup:admin"]},
 
-	// Test access rules every time they're saved.
-	// "tests": [
-	//   {
-	//       "src": "alice@example.com",
-	//       "accept": ["tag:example"],
-	//       "deny": ["100.101.102.103:443"],
-	//   },
-	// ],
+	// Test access rules every time they're saved. These assert the access the
+	// k3s nodes must keep AFTER they become tag-owned (tag:k3s).
+	"tests": [
+		{
+			"src":    "jarrod.servilla@gmail.com",
+			"accept": ["tag:k3s:6443", "tag:k3s:22", "10.2.1.200:443"],
+		},
+		{
+			"src":    "tag:github-actions",
+			"accept": ["tag:k3s:6443"],
+		},
+	],
 }

--- a/terraform/modules/tailscale/main.tf
+++ b/terraform/modules/tailscale/main.tf
@@ -31,5 +31,6 @@ resource "tailscale_tailnet_key" "ci" {
   preauthorized = true
   tags          = ["tag:github-actions"]
   expiry        = var.ci_key_expiry_seconds
-  description   = "TF node-join key (manual/NAS/re-image)"
+  # Tailscale rejects non-alphanumeric chars in key descriptions (no / ( ) -).
+  description = "TF managed node join key"
 }


### PR DESCRIPTION
# feat(terraform): tag:k3s ACL grants + fix tailnet key description

## Summary

**PR 1 of 2** for node tagging. Adds the ACL grants the cluster nodes will need *before* they
become tag-owned, and fixes the tailnet-key description that failed the Phase 2 apply. This PR is
**additive only — no `device_tags`** — so it's a no-op for live connectivity while the nodes stay
user-owned. PR 2 will flip the tags once these grants are proven live.

Also unblocks `tailscale_tailnet_key.ci`: the Phase 2 merge apply **failed** with
`description had invalid characters (400)` (the old `"... (manual/NAS/re-image)"` string), so the
key was never created. Fixed here.

## Why grants first

Tagging a node removes it from `autogroup:member`. `pi4-01` is the **subnet router + exit node**
(advertises `10.2.1.0/24`, `0.0.0.0/0`, `::/0`) for a **shared tailnet**, so a wrong cutover can
lock out cluster + LAN access for two users. Landing the grants additively (safe now) lets us
verify them before the tag flip.

## Changes

**`terraform/modules/tailscale/acl.hujson`**
- `tagOwners`: add `tag:k3s` → `autogroup:admin`
- grants: `autogroup:admin → tag:k3s` (kubectl/SSH to nodes), `autogroup:admin → 10.2.1.0/24`
  (home LAN via pi4-01's route). Scoped to `autogroup:admin` so the shared tailnet's other user
  isn't granted cluster/LAN access.
- `ssh`: add `check` rule `autogroup:admin → tag:k3s` (`autogroup:self` won't cover tag-owned nodes)
- `tests`: assert `jarrod.servilla@gmail.com → tag:k3s:6443/:22`, `→ 10.2.1.200:443`, and
  `tag:github-actions → tag:k3s:6443`

**`terraform/modules/tailscale/main.tf`**
- `tailscale_tailnet_key.ci` description → `"TF managed node join key"` (alphanumeric only)

## Verification

- `POST /api/v2/tailnet/-/acl/validate` → `{}` `200` (syntax + all tests pass).
- Fixed key description verified via a throwaway key create+delete (`201`/`200`).
- `tofu plan` (read-only, against live state):

  ```
  Plan: 1 to add, 1 to change, 0 to destroy.
  ```

  `tailscale_acl.this` updated **in-place** (grants), `tailscale_tailnet_key.ci` **created**
  (completing the failed Phase 2 apply). Zero destroy/replace.

## After merge / apply

1. Confirm the apply succeeds (key created, ACL updated) — `tofu output -raw ci_auth_key`.
2. Sanity-check access is unchanged (kubectl/SSH still work) — grants are additive, so nothing
   should regress.
3. Then **PR 2**: `tailscale_device_tags` applying `tag:k3s` to all four nodes.

> Note: unrelated uncommitted "Phase 6: GitHub Actions secrets" notes in `README.md` / root
> `main.tf` were intentionally left out of this PR.

https://claude.ai/code/session_01FoBeKLNpyt2tUfwgwtHbvo
