### PR TITLE
feat(terraform): tag cluster nodes with tag:k3s (PR2 of 2)

### DIFF
--- a/terraform/modules/tailscale/main.tf
+++ b/terraform/modules/tailscale/main.tf
@@ -1,14 +1,8 @@
-# Tailscale tailnet — ACL-as-code + a tailnet auth key.
+# Tailscale tailnet — ACL-as-code + a tailnet auth key + cluster node tags.
 #
-# Import discipline (mirrors B2): the ACL is import->no-op. Only
-# tailscale_tailnet_key.ci is a CREATE (its `key` secret is never returned on
-# import). HARD STOP: if `tofu plan` shows destroy/replace on the ACL, fix
-# acl.hujson to match live before applying — a bad ACL push can lock the tailnet.
-#
-# Device tags are intentionally NOT managed here: the cluster nodes are currently
-# user-owned (untagged) live, so tagging them would be a real ownership-changing
-# mutation, not an import-no-op. Deferred to a deliberate follow-up (add the node
-# tag to tagOwners + grants in acl.hujson, then apply).
+# The ACL is import->no-op. tailscale_tailnet_key.ci is a CREATE. HARD STOP: if
+# `tofu plan` shows destroy/replace on the ACL, fix acl.hujson to match live
+# before applying — a bad ACL push can lock the tailnet.
 
 # ---------------------------------------------------------------------------
 # ACL-as-code. Kept in acl.hujson so it's diffable as policy, not buried in HCL.
@@ -17,6 +11,25 @@
 # ---------------------------------------------------------------------------
 resource "tailscale_acl" "this" {
   acl = file("${path.module}/acl.hujson")
+}
+
+# ---------------------------------------------------------------------------
+# Cluster node tags. The nodes were user-owned (untagged); this is the deliberate
+# CREATE that moves them to tag-ownership (tag:k3s) so they no longer depend on a
+# personal account or key expiry. The required grants (autogroup:admin -> tag:k3s
+# and -> 10.2.1.0/24, plus SSH) landed in acl.hujson in the prior PR, so this flip
+# does not strand kubectl/SSH/LAN access. The TF OAuth client must own tag:k3s.
+# ---------------------------------------------------------------------------
+data "tailscale_device" "node" {
+  for_each = var.managed_nodes
+  hostname = each.value
+  wait_for = "30s"
+}
+
+resource "tailscale_device_tags" "node" {
+  for_each  = var.managed_nodes
+  device_id = data.tailscale_device.node[each.key].node_id
+  tags      = ["tag:k3s"]
 }
 
 # ---------------------------------------------------------------------------

--- a/terraform/modules/tailscale/outputs.tf
+++ b/terraform/modules/tailscale/outputs.tf
@@ -5,3 +5,9 @@ output "ci_auth_key" {
   value       = tailscale_tailnet_key.ci.key
   sensitive   = true
 }
+
+# Non-secret: logical name -> Tailscale node_id for the tagged cluster nodes.
+output "tagged_device_ids" {
+  description = "Managed node logical name -> Tailscale node_id."
+  value       = { for k, d in data.tailscale_device.node : k => d.node_id }
+}

--- a/terraform/modules/tailscale/variables.tf
+++ b/terraform/modules/tailscale/variables.tf
@@ -4,3 +4,16 @@ variable "ci_key_expiry_seconds" {
   type        = number
   default     = 7776000
 }
+
+# Cluster nodes that TF tags with tag:k3s, keyed by logical name -> Tailscale
+# hostname. Small + stable, so hardcoded. All four get tag:k3s.
+variable "managed_nodes" {
+  description = "Logical name -> Tailscale hostname for nodes TF tags with tag:k3s."
+  type        = map(string)
+  default = {
+    pi4_01 = "pi4-01"
+    pi4_02 = "pi4-02"
+    pi5_01 = "pi5-01"
+    pi5_02 = "pi5-02"
+  }
+}


### PR DESCRIPTION
# feat(terraform): tag cluster nodes with tag:k3s (PR2 of 2)

## Summary

**PR 2 of 2** for node tagging. Flips the four k3s nodes (`pi4-01/02`, `pi5-01/02`) from
**user-owned/untagged** to **tag-owned** (`tag:k3s`) via `tailscale_device_tags`. This decouples
them from the personal `jarrod.servilla@gmail.com` account and removes the per-device key-expiry
footgun (tagged devices never expire).

Safe because **PR1 already landed the grants this flip depends on** (`autogroup:admin → tag:k3s`
and `→ 10.2.1.0/24`, plus the SSH rule), validated by ACL `tests`. So kubectl / SSH / LAN access
survives the cutover. Pure create — no import (the nodes had no tags to adopt).

## ⚠️ PRE-MERGE: OAuth client must own `tag:k3s`

The TF OAuth client can only assign tags it owns, and `tag:k3s` **did not exist when the client
was created** (it was added in PR1). **Before merging**, add `tag:k3s` to this client's tags:

> Tailscale admin → Settings → OAuth clients → (the ACL/TF client) → add `tag:k3s` to its tags.

Without this, the apply fails with a 403 on the first `tailscale_device_tags`.

## Changes

**`terraform/modules/tailscale/main.tf`**
- `data "tailscale_device" "node"` (lookup by hostname) + `resource "tailscale_device_tags" "node"`
  (`tags = ["tag:k3s"]`), `for_each` over `managed_nodes`

**`terraform/modules/tailscale/variables.tf`**
- `managed_nodes` — logical name → Tailscale hostname for the 4 nodes

**`terraform/modules/tailscale/outputs.tf`**
- `tagged_device_ids` (non-secret) — logical name → `node_id`

## Verification

`tofu plan` (read-only, against live state):

```
Plan: 4 to add, 0 to change, 0 to destroy.
```

Four `tailscale_device_tags.node[*]` created with `tag:k3s`; `tailscale_acl.this` and
`tailscale_tailnet_key.ci` unchanged. Zero destroy/replace.

## After merge / apply (verify the cutover)

1. Apply goes green (4 device_tags created).
2. **kubectl still works** (`kubectl get nodes`) and **SSH to nodes** over Tailscale.
3. **LAN reachable** via pi4-01's subnet route; pi4-01 still functions as exit node.
4. `tofu plan` is a clean no-op (tags now in state).

If anything is unreachable: the revert is removing the tags (set back to `[]`) — the grants are
additive and harmless to leave in place.

> Note: unrelated uncommitted "Phase 6: GitHub Actions secrets" notes in `README.md` / root
> `main.tf` were intentionally left out of this PR.

https://claude.ai/code/session_01FoBeKLNpyt2tUfwgwtHbvo
