### PR TITLE
feat(terraform): write TF-managed secrets to GitHub Actions (Phase 6)

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -30,6 +30,14 @@ env:
   # The provider hits public api.tailscale.com — no cluster VPN needed.
   TAILSCALE_OAUTH_CLIENT_ID: ${{ secrets.TS_TF_OAUTH_CLIENT_ID }}
   TAILSCALE_OAUTH_CLIENT_SECRET: ${{ secrets.TS_TF_OAUTH_CLIENT_SECRET }}
+  # github provider (Phase 6) — fine-grained PAT, repo Secrets RW. Hand-made, never TF-managed.
+  GITHUB_TOKEN: ${{ secrets.GH_TF_TOKEN }}
+  GITHUB_OWNER: ${{ github.repository_owner }}
+  # Adopted non-Tier-0 secrets re-supplied as plaintext (lands in encrypted state).
+  TF_VAR_github_owner: ${{ github.repository_owner }}
+  TF_VAR_kube_config: ${{ secrets.KUBE_CONFIG }}
+  TF_VAR_ts_oauth_client_id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+  TF_VAR_ts_oauth_secret: ${{ secrets.TS_OAUTH_SECRET }}
 
 jobs:
   plan:

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -127,6 +127,75 @@ After apply, read the key once: `tofu output -raw ci_auth_key` (Infisical storag
 deferred to Phase 3). The key is for manual/other node joins (NAS, re-imaging a Pi);
 CI does not consume it.
 
+## Phase 6: GitHub Actions secrets (implemented)
+
+Closes the loop on **TF-generated secrets** by writing them straight into GitHub Actions
+secrets, instead of a human running `tofu output -raw …` and pasting into the repo settings.
+Fits the boundary cleanly: GitHub config is **external gap**, not in-cluster — no `helm_release`,
+no `charts/**`. Module: `modules/github/`.
+
+**Final scope landed**: candidate 1 (`TS_TF_CI_AUTH_KEY`, fed from `module.tailscale.ci_auth_key`)
+**+** candidate 3 adoption of `KUBE_CONFIG` / `TS_OAUTH_CLIENT_ID` / `TS_OAUTH_SECRET`. Adopted
+secrets use `value` (plaintext; provider encrypts — `plaintext_value` is deprecated in github
+provider v6) re-supplied via `TF_VAR_*` from the existing live GH secrets — value
+lands in (encrypted) state; accepted. Plan shows **4 creates, zero destroys/replaces**.
+
+### Scope boundary (read before adding any secret)
+
+- TF **owns**: repo Actions secrets whose *value originates in TF* (a TF resource generated it),
+  plus the *existence/metadata* of adopted non-Tier-0 secrets.
+- TF **never manages**: the **4 Tier-0 secrets** — `B2_APPLICATION_KEY_ID` / `B2_APPLICATION_KEY`,
+  `TF_STATE_PASSPHRASE`, and the Infisical bootstrap `INFISICAL_CLIENT_ID` /
+  `INFISICAL_CLIENT_SECRET`. **Chicken-egg:** TF reads state from B2 using exactly these creds, so
+  it cannot bootstrap its own access — they stay in the password manager + hand-set GH secrets
+  forever. Same DR-root logic as §"Tier-0 seeded roots": the password manager is the true root.
+
+### Provider auth (Tier-0-adjacent, hand-made)
+
+The `integrations/github` provider needs a token with `repo` + Actions-secrets write scope —
+a fine-grained PAT (Secrets: read/write on this repo) or a GitHub App installation token. Seed
+it into a GH secret `GH_TF_TOKEN` (+ password manager); the provider reads env `GITHUB_TOKEN`
+and `GITHUB_OWNER`. **Not** a Tier-0 root (TF doesn't need it to reach state), but hand-made and
+never TF-managed (it grants the write access TF uses — self-management is the same chicken-egg).
+
+### Candidate secrets
+
+1. **`TS_TF_CI_AUTH_KEY`** ← `module.tailscale.tailscale_tailnet_key.ci.key`. TF already
+   generates this; today it's surfaced via `tofu output -raw ci_auth_key` and copied by hand.
+   Wiring it to `github_actions_secret.plaintext_value` removes the manual step. Lowest risk,
+   clearest win — the first one to land.
+2. **Future TF-generated values** — reserve the pattern for per-service B2 app keys (Phase 1+),
+   Authentik tokens (Phase 4), and Infisical machine identities (Phase 3). As each TF resource
+   that mints a credential lands, pipe its output into a `github_actions_secret` in the same PR.
+3. **Adopted non-Tier-0 secrets** (`KUBE_CONFIG`, `TS_OAUTH_CLIENT_ID` / `TS_OAUTH_SECRET`) —
+   bring existing manually-set secrets under TF for an inventory-in-code. Caveat: their values
+   do **not** originate in TF, so adoption means re-supplying the value through a `TF_VAR_*`
+   (it then lands in state) — accept the state exposure or skip. Lower priority than 1–2.
+
+### Import discipline does NOT apply
+
+Unlike B2 buckets and the Tailscale ACL, **`github_actions_secret` cannot be import->no-op**:
+the GitHub API never returns a secret's value, so every managed secret is an inherent CREATE
+(same shape as `tailscale_tailnet_key.ci`). Plan-only verification is therefore by *count of
+creates*, not a clean no-op. There's no destroy risk to a live backup here — deleting a managed
+secret only un-sets it in CI — but a wrong value silently breaks a workflow, so apply deliberately.
+
+### State exposure
+
+`plaintext_value` lands in TF state. State is the B2 bucket + native encryption, so it's
+encrypted at rest, but anyone with the state file **and** `TF_STATE_PASSPHRASE` can recover the
+value. For candidate 1 that's already true (the key lives in state via the tailscale module
+output regardless). For candidate 3, prefer `encrypted_value` (sealed client-side with the repo's
+public key via `github_actions_public_key`) if the value is sensitive and not already in state.
+
+### Bootstrap order delta
+
+```
+… (Phases 0–5 as above)
+6. (manual) Create GH_TF_TOKEN PAT/App token -> GH Actions secret + password manager.
+7. tofu apply modules/github   # creates TS_TF_CI_AUTH_KEY first; expand per candidate.
+```
+
 ## HARD STOP rule (import safety)
 
 After import, if `tofu plan` shows ANY `destroy`/replace on a live bucket, **do not apply** —

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -11,6 +11,19 @@ module "tailscale" {
 # Phase 3: module "infisical_platform" { source = "./modules/infisical-platform" }
 # Phase 4: module "authentik"        { source = "./modules/authentik" }
 # Phase 5: module "cluster_bootstrap" { source = "./modules/cluster-bootstrap" }
+
+# Phase 6 — TF-managed credentials pushed straight to GitHub Actions secrets,
+# closing the hand-paste loop. ci_auth_key consumed directly from the tailscale
+# module (no root output needed). Adopted secrets fed plaintext via TF_VAR_*.
+module "github" {
+  source      = "./modules/github"
+  ci_auth_key = module.tailscale.ci_auth_key
+  adopted_secrets = {
+    KUBE_CONFIG        = var.kube_config
+    TS_OAUTH_CLIENT_ID = var.ts_oauth_client_id
+    TS_OAUTH_SECRET    = var.ts_oauth_secret
+  }
+}
 # DNS:     module "dns"              { source = "./modules/dns" }
 
 # ---------------------------------------------------------------------------

--- a/terraform/modules/github/main.tf
+++ b/terraform/modules/github/main.tf
@@ -1,0 +1,24 @@
+# GitHub Actions secrets — TF-managed credentials pushed straight to repo Secrets,
+# closing the hand-paste loop (e.g. the tailnet node-join key).
+#
+# CREATE-only discipline (mirrors tailscale_tailnet_key.ci): the GitHub API never
+# returns a secret's value, so there is no import->no-op possible. Every managed
+# secret is an inherent CREATE. This module verifies by COUNT OF CREATES, not a
+# clean no-op plan. Boundary: external/cloud gap only — never charts/** or workloads.
+
+resource "github_actions_secret" "ci_auth_key" {
+  repository  = var.repository
+  secret_name = "TS_TF_CI_AUTH_KEY"
+  value       = var.ci_auth_key # plaintext; provider encrypts. (plaintext_value deprecated in v6)
+}
+
+# for_each over the secret NAMES only — keys() of a sensitive map is itself
+# derived-sensitive, but the names (KUBE_CONFIG, …) are not secret, so nonsensitive()
+# is safe and required (sensitive values can't be for_each keys). The value lookup
+# stays sensitive -> plaintext_value stays sensitive.
+resource "github_actions_secret" "adopted" {
+  for_each    = nonsensitive(toset(keys(var.adopted_secrets)))
+  repository  = var.repository
+  secret_name = each.key
+  value       = var.adopted_secrets[each.key]
+}

--- a/terraform/modules/github/outputs.tf
+++ b/terraform/modules/github/outputs.tf
@@ -1,0 +1,5 @@
+# Non-secret inventory of what this module manages. Names only — never values.
+output "managed_secret_names" {
+  description = "Actions secret names managed by this module."
+  value       = concat(["TS_TF_CI_AUTH_KEY"], nonsensitive(keys(var.adopted_secrets)))
+}

--- a/terraform/modules/github/variables.tf
+++ b/terraform/modules/github/variables.tf
@@ -1,0 +1,18 @@
+variable "repository" {
+  description = "GitHub repo (name only) that receives the Actions secrets."
+  type        = string
+  default     = "homelab-k8s"
+}
+
+variable "ci_auth_key" {
+  description = "TF-managed tailnet auth key, fed from module.tailscale.ci_auth_key. Written to Actions secret TS_TF_CI_AUTH_KEY."
+  type        = string
+  sensitive   = true
+}
+
+variable "adopted_secrets" {
+  description = "Logical SECRET_NAME -> plaintext value for pre-existing live secrets adopted into TF (KUBE_CONFIG / TS_OAUTH_CLIENT_ID / TS_OAUTH_SECRET). Supplied via TF_VAR_* — lands in encrypted state."
+  type        = map(string)
+  default     = {}
+  sensitive   = true
+}

--- a/terraform/modules/github/versions.tf
+++ b/terraform/modules/github/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    github = {
+      source  = "integrations/github"
+      version = "~> 6.0"
+    }
+  }
+}

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -7,3 +7,9 @@ provider "b2" {}
 provider "tailscale" {
   tailnet = "-"
 }
+
+# Credentials from env: GITHUB_TOKEN (hand-made fine-grained PAT GH_TF_TOKEN, repo
+# Secrets RW + Metadata R). Never TF-managed (self-management = chicken-egg).
+provider "github" {
+  owner = var.github_owner
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -3,3 +3,28 @@ variable "state_passphrase" {
   type        = string
   sensitive   = true
 }
+
+variable "github_owner" {
+  description = "GitHub owner for the github provider. Set via TF_VAR_github_owner (CI: github.repository_owner)."
+  type        = string
+}
+
+# Adopted non-Tier-0 secrets re-supplied as plaintext via TF_VAR_* from live GH
+# secrets. Accept state exposure (B2 + native PBKDF2/AES encryption at rest).
+variable "kube_config" {
+  description = "Adopted: KUBE_CONFIG. Supplied via TF_VAR_kube_config."
+  type        = string
+  sensitive   = true
+}
+
+variable "ts_oauth_client_id" {
+  description = "Adopted: TS_OAUTH_CLIENT_ID. Supplied via TF_VAR_ts_oauth_client_id."
+  type        = string
+  sensitive   = true
+}
+
+variable "ts_oauth_secret" {
+  description = "Adopted: TS_OAUTH_SECRET. Supplied via TF_VAR_ts_oauth_secret."
+  type        = string
+  sensitive   = true
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -10,5 +10,9 @@ terraform {
       source  = "tailscale/tailscale"
       version = "~> 0.29"
     }
+    github = {
+      source  = "integrations/github"
+      version = "~> 6.0"
+    }
   }
 }


### PR DESCRIPTION
# feat(terraform): write TF-managed secrets to GitHub Actions (Phase 6)

## Summary

Closes the hand-paste loop. Until now, TF-generated credentials (e.g. the Tailscale node-join
key) were surfaced via `tofu output -raw …` and **hand-pasted** into GitHub repo Actions secrets.
Phase 6 adds `terraform/modules/github/`, which writes those values straight into GitHub Actions
secrets via the `integrations/github` provider.

Boundary holds: GitHub config is the external/cloud gap, **not** in-cluster — no `helm_release`,
no `charts/**`. The 4 **Tier-0 secrets** (`B2_APPLICATION_KEY_ID`/`B2_APPLICATION_KEY`,
`TF_STATE_PASSPHRASE`, Infisical bootstrap `INFISICAL_CLIENT_ID`/`INFISICAL_CLIENT_SECRET`) are
**never** TF-managed — chicken-egg: TF reads its own state from B2 using exactly those.

## Scope

- **Candidate 1**: `TS_TF_CI_AUTH_KEY` ← `module.tailscale.ci_auth_key` (TF already generates it).
- **Candidate 3 (adopted)**: `KUBE_CONFIG`, `TS_OAUTH_CLIENT_ID`, `TS_OAUTH_SECRET` — brought
  under TF for inventory-in-code. Values don't originate in TF, so they're re-supplied as
  plaintext via `TF_VAR_*` from the existing live secrets, landing in (encrypted) state — accepted
  (state is B2 + native PBKDF2/AES at rest).

## CREATE-only by design (no import → no-op)

Unlike B2 buckets and the Tailscale ACL, `github_actions_secret` **cannot** be import→no-op: the
GitHub API never returns a secret's value, so every managed secret is an inherent CREATE (same
shape as `tailscale_tailnet_key.ci`). This module verifies by **count of creates**, not a clean
no-op.

## Verified plan (local)

```
Plan: 4 to add, 0 to change, 0 to destroy.
```

`module.github.github_actions_secret.{ci_auth_key, adopted["KUBE_CONFIG"],
adopted["TS_OAUTH_CLIENT_ID"], adopted["TS_OAUTH_SECRET"]}` — all create, zero destroy/replace.

## Implementation notes

- Uses `value` (not the v6-deprecated `plaintext_value`); provider encrypts client-side.
- The adopted `for_each` iterates `nonsensitive(toset(keys(...)))` — secret **names** aren't
  secret, and a sensitive value can't be a `for_each` key. The value lookup stays sensitive.
- Provider auth: hand-made **fine-grained PAT** `GH_TF_TOKEN` (repo Secrets RW + Metadata R),
  read from env `GITHUB_TOKEN`. Not a Tier-0 root, but never TF-managed (self-management = same
  chicken-egg).

## Operator prerequisite (before merge)

Create the `GH_TF_TOKEN` PAT and set it as a repo Actions secret (+ store in password manager),
**else the `plan`/`apply` provider init fails**.

## Files

- `terraform/modules/github/{versions,variables,main,outputs}.tf` (new)
- `terraform/{versions,providers,variables,main}.tf`
- `.github/workflows/terraform.yml`
- `terraform/README.md`

https://claude.ai/code/session_01GK7T9nW2bhXG9oeDhaz4UD
